### PR TITLE
Update create_venv.sh

### DIFF
--- a/create_venv.sh
+++ b/create_venv.sh
@@ -149,7 +149,7 @@ else
 			wget "$VIRTUALENV_URL" || error "Failed to download virtualenv"
 		elif [[ ! -z "$(command -v curl 2> /dev/null)" ]]
 		then
-			curl "$VIRTUALENV_URL" -o virtualenv-15.0.3.tar.gz || error "Failed to download virtualenv"
+			curl -L "$VIRTUALENV_URL" -o virtualenv-15.0.3.tar.gz || error "Failed to download virtualenv"
 		else
 			error "Can't find a download tool (tried wget and curl), cannot download virtualenv"
 		fi


### PR DESCRIPTION
from Uwe Lange (ulange@eso.org)
If your system only has curl installed (like on my minimal CentOS 7.6 VM) then curl needs option '-L' to follow a redirect otherwise download of $VIRTUALENV_URL fails