### PR TITLE
Add simple tox config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ fabfile/authorized_keys
 # The directory with the HTML report
 # generated with "coverage html"
 htmlcov/
+
+.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27,py37
+skipsdist = True
+
+[testenv]
+commands =
+    {toxinidir}/build.sh
+    pytest {posargs}
+deps =
+    pytest
+    wheel
+    psutil


### PR DESCRIPTION
[Tox](https://tox.readthedocs.io/en/latest/) is virtualenv manager for test - it installs the requirements, the package to test, and runs the tests within a virtualenv (creating a new venv for each python version). This adds a simple one (so that I don't need to remember to run build.sh every time I want to run the tests or remeber to install psutil in every venv ;)), but it's fairly easy to add features if need be (see https://github.com/h5py/h5py/blob/master/tox.ini for some of the power tox gives to control the test environment).