### PR TITLE
Add https to core system

### DIFF
--- a/.travis/run_tests.sh
+++ b/.travis/run_tests.sh
@@ -40,7 +40,7 @@ then
 	source ${TRAVIS_BUILD_DIR}/osx_venv/bin/activate
 fi
 
-pip install psutil pytest-cov coveralls || fail "Failed to install unit test dependencies"
+pip install psutil pytest-cov coveralls trustme || fail "Failed to install unit test dependencies"
 
 # Try to simply import the plugin modules
 # This increases our coverage by a not-too-small amount

--- a/src/ngamsCore/ngamsLib/ngamsStatus.py
+++ b/src/ngamsCore/ngamsLib/ngamsStatus.py
@@ -923,7 +923,10 @@ def to_status(http_response, host_id, cmd):
     instead.
     """
 
-    data = http_response.read()
+    if hasattr(http_response, 'read'):
+        data = http_response.read()
+    else:
+        data = http_response.content
     if data and b'<?xml' in data:
         logger.debug("Parsing incoming HTTP data as ngamsStatus")
         return ngamsStatus().unpackXmlDoc(data, 1)

--- a/src/ngamsCore/ngamsLib/ngamsSubscriber.py
+++ b/src/ngamsCore/ngamsLib/ngamsSubscriber.py
@@ -57,8 +57,8 @@ def validate_url(url):
     if not parse_result.netloc:
         raise ValueError("No netloc found in URL %s. Value interpreted as %r" % (url, parse_result,))
 
-    if parse_result.scheme != 'http':
-        msg = "%s scheme not currently supported, only http:// scheme allowed"
+    if parse_result.scheme not in ('http', 'https'):
+        msg = "%s scheme not currently supported, only http or https scheme allowed"
         raise ValueError(msg % parse_result.scheme)
 
 

--- a/src/ngamsCore/ngamsLib/pysendfile.py
+++ b/src/ngamsCore/ngamsLib/pysendfile.py
@@ -190,6 +190,17 @@ def _check_sendfile_params(sock, file, offset, count):
             raise ValueError(
                 "count must be a positive integer (got %s)" % repr(count))
 
+def sendfile_send(sock, file, offset=0, count=None):
+    """sendfile_send(sock, file[, offset[, count]]) -> sent
+
+    API-compatible version of sendfile which does not use the sendfile system
+    call. The purpose of this is to allow users to disable usage of sendfile
+    (either in the case where https is used on the server and sendfile breaks,
+    or some other situation where sendfile is problematic). See the sendfile
+    function for more details about arguments.
+    """
+    return _sendfile_use_send(sock, file, offset, count)
+
 
 def sendfile(sock, file, offset=0, count=None):
     """sendfile(sock, file[, offset[, count]]) -> sent

--- a/src/ngamsCore/setup.py
+++ b/src/ngamsCore/setup.py
@@ -30,7 +30,7 @@ with open('../../VERSION') as vfile:
             break
 
 # We definitely require this one
-install_requires = ['DBUtils', 'six>=1.10']
+install_requires = ['DBUtils', 'six>=1.10', 'requests']
 
 # In python 3.3+ we use os.sendfile, otherwise we require pysendfile.sendfile
 if sys.version_info[0:2] < (3, 3):

--- a/src/ngamsServer/ngamsServer/janitor/rotated_logfiles_handler.py
+++ b/src/ngamsServer/ngamsServer/janitor/rotated_logfiles_handler.py
@@ -71,7 +71,9 @@ def run(srvObj, stopEvt):
         if cfg.getArchiveRotatedLogfiles():
             file_uri = "file://" + fname
             host, port = srvObj.get_self_endpoint()
-            ngamsPClient.ngamsPClient(host, port).archive(file_uri, 'ngas/nglog')
+            proto = srvObj.get_server_access_proto()
+            ngamsPClient.ngamsPClient(host, port, proto=proto).archive(
+                    file_uri, 'ngas/nglog')
 
         # Do additional things with our logfiles
         for plugin in get_logfile_handler_plugins(cfg):

--- a/src/ngamsServer/ngamsServer/ngamsSubscriptionThread.py
+++ b/src/ngamsServer/ngamsServer/ngamsSubscriptionThread.py
@@ -765,7 +765,7 @@ def _deliveryThread(srvObj,
 
                 except Exception as e:
                     ex = str(e)
-                    logger.error('%s Message: %s' % (ex, stat.getMessage()))
+                    logger.exception('%s Message: %s' % (ex, stat.getMessage()))
 
                 if ex or reply != NGAMS_HTTP_SUCCESS or stat.getStatus() == NGAMS_FAILURE:
 

--- a/test/client/test_python_client.py
+++ b/test/client/test_python_client.py
@@ -629,4 +629,4 @@ class CommandLineTest(ngamsTestSuite):
 
         # Wrong subscriptions: missing URL, URL scheme not supported
         self.assert_client_fails('SUBSCRIBE')
-        self.assert_client_fails('SUBSCRIBE', '--url', 'https://somewhere:8907/QARCHIVE')
+        self.assert_client_fails('SUBSCRIBE', '--url', 'ftp://somewhere:8907/QARCHIVE')

--- a/test/ngamsTestLib.py
+++ b/test/ngamsTestLib.py
@@ -53,6 +53,7 @@ import struct
 import subprocess
 import sys
 import tempfile
+from tempfile import mkstemp
 import threading
 import time
 import unittest
@@ -61,6 +62,7 @@ import xml.dom.minidom
 import astropy.io.fits as pyfits
 import pkg_resources
 import psutil
+import requests
 import six
 from six.moves import zip_longest, socketserver
 
@@ -71,7 +73,6 @@ from ngamsLib.ngamsCore import getHostName, rmFile, \
     checkCreatePath
 from ngamsPClient import ngamsPClient
 from ngamsServer import volumes, ngamsServer
-
 
 logger = logging.getLogger(__name__)
 
@@ -667,7 +668,7 @@ class InMemorySMTPServer(smtpd.SMTPServer):
             self.recv_evt.set()
             self.recv_cond.notify_all()
 
-ServerInfo = collections.namedtuple('ServerInfo', ['proc', 'port', 'rootDir', 'cfg_file', 'daemon'])
+ServerInfo = collections.namedtuple('ServerInfo', ['proc', 'port', 'rootDir', 'cfg_file', 'daemon', 'proto'])
 
 class ngamsTestSuite(unittest.TestCase):
     """
@@ -694,21 +695,21 @@ class ngamsTestSuite(unittest.TestCase):
         self._clients = None
         self.smtp_server = None
 
-    def _add_client(self, port):
+    def _add_client(self, port, proto='http'):
         # We overwrite any client that we may have created on that port already
         if self.client is None:
-            self.client = self.get_client(port)
+            self.client = self.get_client(port, proto=proto)
             return
         if self._clients is None:
             old_port = self.client.servers[0][1]
             if old_port == port:
-                self.client = self.get_client(port)
+                self.client = self.get_client(port, proto=proto)
                 return
             self._clients = {self.client.servers[0][1]: self.client,
-                             port: self.get_client(port)}
+                             port: self.get_client(port, proto=proto)}
             self.client = lambda x: self._clients[x]
         else:
-            self._clients[port] = self.get_client(port)
+            self._clients[port] = self.get_client(port, proto=proto)
 
     def _remove_client(self, port):
         if self._clients is not None:
@@ -737,8 +738,10 @@ class ngamsTestSuite(unittest.TestCase):
         cfg.save(cfg_fname, 0)
         return cfg_fname
 
-    def get_client(self, port=8888, auth=None, timeout=60.0):
-        return ngamsPClient.ngamsPClient(port=port, auth=auth, timeout=timeout)
+    def get_client(self, port=8888, auth=None, timeout=60.0, proto='http'):
+        return ngamsPClient.ngamsPClient(
+            port=port, auth=auth, timeout=timeout, proto=proto,
+        )
 
     def _assert_client_call(self, method, *args, **kwargs):
         '''Generic assertion on the NGAS status returned by clients'''
@@ -876,7 +879,8 @@ class ngamsTestSuite(unittest.TestCase):
                    dbCfgName = None,
                    srvModule = None,
                    force=False,
-                   daemon = False):
+                   daemon = False,
+                   cert_file=None):
         """
         Prepare a standard server object, which runs as a separate process and
         serves via the standard HTTP interface.
@@ -980,6 +984,13 @@ class ngamsTestSuite(unittest.TestCase):
         if autoOnline:   execCmd.append("-autoonline")
         if dbCfgName:    execCmd.extend(["-dbcfgid", dbCfgName])
 
+        if cert_file:
+            execCmd.extend(["-cert", cert_file])
+            proto = 'https'
+        else:
+            proto = 'http'
+        logger.info('Using %s for server', proto)
+
         # Make sure spawned servers use the same tmp dir base as we do, since
         # some of them use unit-test-provided code to perform some checks, and
         # sometimes communicate through files in the temporary area
@@ -991,8 +1002,8 @@ class ngamsTestSuite(unittest.TestCase):
             srvProcess = subprocess.Popen(execCmd, shell=False, env=environ)
 
         # We have to wait until the server is serving.
-        server_info = ServerInfo(srvProcess, port, cfgObj.getRootDirectory(), tmpCfg, daemon)
-        client = self.get_client(port=port, timeout=5)
+        server_info = ServerInfo(srvProcess, port, cfgObj.getRootDirectory(), tmpCfg, daemon, proto)
+        client = self.get_client(port=port, timeout=5, proto=proto)
 
         def give_up():
             try:
@@ -1036,6 +1047,10 @@ class ngamsTestSuite(unittest.TestCase):
                     logger.debug("Polled server - not yet running ...")
                     time.sleep(0.1)
                     continue
+                elif isinstance(e, requests.ConnectionError):
+                    logger.debug("Polled server - not yet running ...")
+                    time.sleep(0.1)
+                    continue
 
                 # We are having this funny situation in MacOS builds, when
                 # intermittently the client times out while trying to connect
@@ -1073,7 +1088,7 @@ class ngamsTestSuite(unittest.TestCase):
                 raise
 
         self.extSrvInfo.append(server_info)
-        self._add_client(port)
+        self._add_client(port, proto=proto)
         return (cfgObj, dbObj)
 
     def restart_last_server(self, before_restart=None, start=None, **kwargs):
@@ -1091,7 +1106,7 @@ class ngamsTestSuite(unittest.TestCase):
         Terminate an externally running server.
         """
 
-        srvProcess, port, rootDir, cfg_file, daemon = srvInfo
+        srvProcess, port, rootDir, cfg_file, daemon, proto = srvInfo
 
         # Started as a daemon, stopped as a daemon
         # Here we trust that the daemon will shut down all the processes nicely,
@@ -1120,7 +1135,8 @@ class ngamsTestSuite(unittest.TestCase):
 
         logger.debug("Killing externally running NG/AMS Server. PID: %d, Port: %d ", srvProcess.pid, port)
         try:
-            client = self.get_client(port=port, auth=auth, timeout=10)
+            client = self.get_client(
+                port=port, auth=auth, timeout=10, proto=proto)
             stat = client.status()
             if stat.getState() != "OFFLINE":
                 logger.info("Sending OFFLINE command to external server ...")
@@ -1369,7 +1385,9 @@ class ngamsTestSuite(unittest.TestCase):
             logger.info("Error encountered: %s", errMsg.replace("\n", " | "))
             self.fail(errMsg)
 
-    def start_srv_in_cluster(self, multSrvs, comCfgFile, srvInfo):
+    def start_srv_in_cluster(
+        self, multSrvs, comCfgFile, srvInfo, cert_file=None
+    ):
         """
         Starts a given server which is part of a cluster of servers
         """
@@ -1400,11 +1418,12 @@ class ngamsTestSuite(unittest.TestCase):
         # Start server + add reference to server configuration object and
         # server DB object.
         cfg, db = self.prepExtSrv(port=port, delDirs=0, clearDb=0, autoOnline=1,
-                                  cfgFile=tmpCfgFile, root_dir=mtRtDir)
+                                  cfgFile=tmpCfgFile, root_dir=mtRtDir,
+                                  cert_file=cert_file)
         return [srvId, port, cfg, db]
 
     def prepCluster(self, server_list, cfg_file='src/ngamsCfg.xml', createDatabase=True,
-                    cfg_props=()):
+                    cfg_props=(), cert_file=None):
         """
         Prepare a common, simulated cluster. This consists of 1 to N
         servers running on the same node. It is ensured that each of
@@ -1450,13 +1469,15 @@ class ngamsTestSuite(unittest.TestCase):
         multSrvs = len(server_list) > 1
 
         # Start them in parallel now that we have all set up for it
-        res = srv_mgr_pool.map(functools.partial(self.start_srv_in_cluster, multSrvs, cfg_file), server_list)
+        res = srv_mgr_pool.map(functools.partial(self.start_srv_in_cluster, multSrvs, cfg_file, cert_file=cert_file), server_list)
+
+        proto = 'https' if cert_file else 'http'
 
         # srvId: (cfgObj, dbObj), in same input order
         d = collections.OrderedDict()
         for r in res:
             d[r[0]] = (r[2], r[3])
-            self._add_client(r[1])
+            self._add_client(r[1], proto=proto)
 
         return d
 
@@ -1774,6 +1795,5 @@ class ngamsTestSuite(unittest.TestCase):
 
         self.markNodesAsUnsusp(dbConObj, nodes)
         self.fail("Sub-node not woken up within %ds" % timeOut)
-
 
 # EOF

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,23 @@ envlist = py27,py37
 skipsdist = True
 
 [testenv]
+passenv =
+    LD_PRELOAD
+    SSLKEYLOGFILE
+# These are used to assist in debugging https support - see https://git.lekensteyn.nl/peter/wireshark-notes/tree/src/sslkeylog.c
+
 commands =
     {toxinidir}/build.sh
-    pytest {posargs}
+    pytest --cov {posargs}
 deps =
     pytest
+    pytest-cov
     wheel
     psutil
+    trustme >= 0.5
+# this are the install requirements, they're here so that wheels are used to speed up the install
+    numpy
+    astropy
+    DBUtils
+    py37: bsddb3
+    py27: pysendfile


### PR DESCRIPTION
This adds some HTTPS support to NGAS. The main changes are whether sendfile is used (it's possible to use sendfile with https, but you need a recent linux kernel, very new openssl etc., so it makes sense to wait until that has stabilised before trying to add that), and using urls where possible to keep around the protocols. Let me know if there are any issues with this (I don't think there are any breaking changes.

Closes #8.