### PR TITLE
Allow subscription to use authentication plugins

### DIFF
--- a/cfg/sample_server_config.xml
+++ b/cfg/sample_server_config.xml
@@ -590,4 +590,13 @@ passwords will be expressed literally.
 		               FilterPlugInPars="5,6,7,8"/>
 	</SubscriptionDef>
 
+	<!--
+	    Authentication to use for subscriptions.
+
+        This section specifies the authentication plugin to use when sending
+        files via the subscription system. See the documentation for more
+        information, or see the example plugin included below.
+	-->
+    <SubscriptionAuth Id="SubscriptionAuth" PlugInName="ngas_sub_auth_plugin">
+
 </NgamsCfg>

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -54,6 +54,14 @@ Changelog
 * Fixed small issue in ``QUERY`` command
   where column names where not correctly aligned
   with the underlying column data.
+* Added support for using HTTPS with both the client and with subscriptions.
+  Support for wrapping the server with TLS has also been added, but this should
+  only be used for testing, rather than in production (we recommend handling
+  HTTPS with more traditional HTTPS servers such as Apache or Nginx).
+* Added support for using more diverse authentication plugins for subscription,
+  via the authentication mechanisms provided by requests. Note that with the
+  current setup, the authentication plugins can only be used with HTTPS (this
+  may change in the future).
 
 .. rubric:: 11.0.2
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -321,3 +321,28 @@ Each ``User`` element should have the following attributes:
 * *Password*: The base64-encoded password.
 * *Commands*: A comma-separated list of commands this user is allowed to
   execute. The special value ``*`` is interpreted as all commands.
+
+
+SubscriptionAuth
+----------------
+
+The ``SubscriptionAuth`` element defines the authentication/authorisation
+configuration to use when acting as a client when using the subscription
+service. Currently it has only one element ``PlugInName``, which follows the
+usual rules for plugins as noted above, with ``PlugInName`` being the name of
+the module to import. This module should have a callable which matches with the
+signature:
+
+.. py:function:: ngas_subscriber_auth(filename, url)
+
+    Provides authentication information needed to send ``filename`` to ``url``.
+
+    This function should return an object that can be handled by the ``auth``
+    keyword argument of requests.reqeusts, which is generally either a string,
+    or an instance of ``requests.auth.AuthBase``. ``None`` can be returned in
+    the case where the authentication is not needed.
+
+    :param str filename: The filename to be sent
+    :param str url: The url to send the filename to
+    :return: An object used by requests to authenticate the connection
+    :rtype: requests.auth.AuthBase, None, str

--- a/src/ngamsCore/ngamsLib/ngamsConfig.py
+++ b/src/ngamsCore/ngamsLib/ngamsConfig.py
@@ -2171,7 +2171,5 @@ class ngamsConfig:
             return None
 
         plugin = loadPlugInEntryPoint(plugin_name, "ngas_subscriber_auth")
-        if plugin is None:
-            return None
 
         return plugin(filename=filename, url=url)

--- a/src/ngamsCore/ngamsLib/ngamsConfig.py
+++ b/src/ngamsCore/ngamsLib/ngamsConfig.py
@@ -42,7 +42,10 @@ import six
 from . import ngamsConfigBase, ngamsSubscriber
 from . import ngamsStorageSet, ngamsStream, ngamsMirroringSource
 from . import utils
-from .ngamsCore import genLog, NGAMS_UNKNOWN_MT, isoTime2Secs, NGAMS_BACK_LOG_DIR
+from .ngamsCore import (
+    genLog, NGAMS_UNKNOWN_MT, isoTime2Secs, NGAMS_BACK_LOG_DIR,
+    loadPlugInEntryPoint,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -2161,3 +2164,14 @@ class ngamsConfig:
             val = 'null'
 
         return val
+
+    def getSubscriptionAuth(self, filename, url):
+        plugin_name = self.getVal("NgamsCfg.SubscriptionAuth[1].PlugInName")
+        if plugin_name is None:
+            return None
+
+        plugin = loadPlugInEntryPoint(plugin_name, "ngas_subscriber_auth")
+        if plugin is None:
+            return None
+
+        return plugin(filename=filename, url=url)

--- a/src/ngamsPlugIns/ngamsPlugIns/ngas_sub_auth_plugin.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngas_sub_auth_plugin.py
@@ -1,0 +1,38 @@
+import base64
+from requests.auth import HTTPBasicAuth
+
+
+def ngas_subscriber_auth_None(filename, url):
+    """
+    Don't do anything special with subscriptions
+    """
+    return None
+
+
+def ngas_subscriber_auth_basic(filename, url):
+    """
+    Use HTTP Basic Auth to connect to server
+    """
+    return HTTPBasicAuth('ngas-int', base64.b64encode(b'ngas-int'))
+
+
+def ngas_subscriber_auth_digest(filename, url):
+    """
+    Use HTTP Digest Auth to connect to server
+    """
+    return HTTPDigestAuth('ngas-int', base64.b64encode(b'ngas-int'))
+
+
+def ngas_subscriber_auth_switch(filename, url):
+    """
+    Use different settings based on url
+
+    https://toolbelt.readthedocs.io/en/latest/authentication.html#authhandler
+    would be an alternative to switching based on url
+    """
+    if "ngas1" in url:
+        return HTTPDigestAuth('ngas-int1', base64.b64encode(b'ngas-int1'))
+    return HTTPDigestAuth('ngas-int', base64.b64encode(b'ngas-int'))
+
+
+ngas_subscriber_auth = ngas_subscriber_auth_None

--- a/src/ngamsServer/ngamsServer/ngamsSubscriptionThread.py
+++ b/src/ngamsServer/ngamsServer/ngamsSubscriptionThread.py
@@ -748,6 +748,12 @@ def _deliveryThread(srvObj,
                         hdrs = {NGAMS_HTTP_HDR_CHECKSUM: fileChecksum}
                         if fileInfoObjHdr:
                             hdrs[NGAMS_HTTP_HDR_FILE_INFO] = fileInfoObjHdr
+
+                        sub_auth = srvObj.getCfg().getSubscriptionAuth(
+                            filename=filename, url=sendUrl
+                        )
+                        if sub_auth is not None:
+                            authHdr = sub_auth
                         with open(filename, "rb") as f:
                             reply, msg, hdrs, data = \
                                    ngamsHttpUtils.httpPostUrl(sendUrl, f, fileMimeType,

--- a/test/support/subscription_auth_plugin.py
+++ b/test/support/subscription_auth_plugin.py
@@ -1,0 +1,10 @@
+import base64
+from logging import getLogger
+
+from requests.auth import HTTPBasicAuth
+
+log = getLogger(__name__)
+
+def ngas_subscriber_auth(filename, url):
+    log.info("Using subscription plugin")
+    return HTTPBasicAuth('ngas-int', base64.b64encode(b'ngas-int'))


### PR DESCRIPTION
Building on #8, this allows services which use the requests code path (so currently just https) to be able to specify which authentication to use for a connection when subscribing. The test uses BasicAuth, but any requests authentication plugin will work (DC is planning on using JWT, as mention in #9), as long as they can be used with the auth argument (OAUTH2 requires a bigger setup, but I doubt that people are going to use it with ngas...). Let me know if this seems reasonable.  

This also adds an [editorconfig](https://editorconfig.org/) file so that hopefully no matter what editor people use, the formatting should be the same (I can drop this from the PR if you'd prefer).