### PR TITLE
Fix bugs where lastDelivery is None in comparison

### DIFF
--- a/src/ngamsServer/ngamsServer/ngamsSubscriptionThread.py
+++ b/src/ngamsServer/ngamsServer/ngamsSubscriptionThread.py
@@ -334,7 +334,7 @@ def _checkIfDeliverFile(srvObj,
     fileBackLogBuffered = fileInfo[FILE_BL]
     subs_start = subscrObj.getStartDate()
 
-    if lastSchedule is not None and lastSchedule > lastDelivery:
+    if lastDelivery is not None and lastSchedule is not None and lastSchedule > lastDelivery:
         # assume what have been scheduled are already delivered, this avoids multiple schedules for the same file across multiple main thread iterations
         # (so that we do not have to block the main iteration anymore)
         # if a file is scheduled but fail to deliver, it will be picked up by backlog in the future


### PR DESCRIPTION
It looks like if the first delivery fails due to an exception (in our case a certificate problem, but any exception will do), `lastDelivery` can be `None` where `lastSchedule` isn't. This adds one more check to the if statement to cover that case.