### PR TITLE
Python client improvements

### DIFF
--- a/src/ngamsPClient/ngamsPClient/ngamsPClient.py
+++ b/src/ngamsPClient/ngamsPClient/ngamsPClient.py
@@ -817,7 +817,7 @@ def main():
     """
 
     DUMP_TO_STDOUT = object()
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(usage="ngamsPClient [-h] <options> cmd")
     parser.add_argument('cmd', help='Command to issue')
 
     gparser = parser.add_argument_group('General options')

--- a/src/ngamsPClient/ngamsPClient/ngamsPClient.py
+++ b/src/ngamsPClient/ngamsPClient/ngamsPClient.py
@@ -818,7 +818,7 @@ def main():
 
     DUMP_TO_STDOUT = object()
     parser = argparse.ArgumentParser(usage="ngamsPClient [-h] <options> cmd")
-    parser.add_argument('cmd', help='Command to issue')
+    parser.add_argument('cmd', nargs='?', help='Command to issue')
 
     gparser = parser.add_argument_group('General options')
     gparser.add_argument('-L', '--license', help='Show the license information', action='store_true')
@@ -877,10 +877,11 @@ def main():
     if opts.version:
         print(getNgamsVersion())
         return
-
-    if opts.license:
+    elif opts.license:
         print(getNgamsLicense())
         return
+    elif not opts.cmd:
+        parser.error('cmd required but none given')
 
     if opts.servers:
         servers = [(host, int(port)) for s in opts.servers.split(',') for host,port in s.split(':')]

--- a/src/ngamsPClient/ngamsPClient/ngamsPClient.py
+++ b/src/ngamsPClient/ngamsPClient/ngamsPClient.py
@@ -816,6 +816,7 @@ def main():
     Entry point for the ngamsPClient script
     """
 
+    DUMP_TO_STDOUT = object()
     parser = argparse.ArgumentParser()
     parser.add_argument('cmd', help='Command to issue')
 
@@ -823,6 +824,8 @@ def main():
     gparser.add_argument('-L', '--license', help='Show the license information', action='store_true')
     gparser.add_argument('-V', '--version', help='Show the version and exit', action='store_true')
     gparser.add_argument('-v', '--verbose', help='Increase verbosity. More -v is more verbose', action='count', default=3)
+    gparser.add_argument('-s', '--status',  metavar="FILE", nargs='?', const=DUMP_TO_STDOUT,
+                         help='Display the XML status document of the command. If FILE is given the document written to disk', )
 
     cparser = parser.add_argument_group('Connection options')
     cparser.add_argument('-H', '--host',    help='Host to connect to', default="127.0.0.1")
@@ -834,7 +837,6 @@ def main():
     parser.add_argument('-r', '--reload',       help='Reload the module implementing the command', action='store_true')
 
     parser.add_argument('-m', '--mime-type',    help='The mime-type', default='application/octet-stream')
-    parser.add_argument('-s', '--show-status',  help='Display the status of the command', action='store_true')
     parser.add_argument('-o', '--output',       help='File/directory where to store the retrieved data')
 
     parser.add_argument('-a', '--async',         help='Run command asynchronously', action='store_true', dest='asynchronous')
@@ -965,9 +967,13 @@ def main():
         if opts.verbose > 4 and stat.getData():
             print(stat.getData())
 
-    if opts.show_status:
-        print(stat.genXml(0, 1, 1, 1).toprettyxml('  ', '\n')[0:-1])
-        print(stat.getStatus())
+    if opts.status:
+        xml = stat.genXml(0, 1, 1, 1).toprettyxml('  ', '\n')[0:-1]
+        if opts.status == DUMP_TO_STDOUT:
+            print(xml)
+        else:
+            with open(opts.status, 'w') as f:
+                f.write(xml)
 
     if stat.getStatus() == NGAMS_FAILURE:
         sys.exit(1)

--- a/test/client/test_python_client.py
+++ b/test/client/test_python_client.py
@@ -551,9 +551,10 @@ class CommandLineTest(ngamsTestSuite):
             self.fail('Failure when executing "%s" (exit code %d)\nstdout: %s\n\nstderr:%s' % (cmdline, ecode, out, err))
         elif not success_expected and ecode == 0:
             self.fail('Successfully executed "%s"\nstdout: %s\n\nstderr:%s' % (cmdline, out, err))
+        return out, err
 
     def assert_client_succeeds(self, *args):
-        self._assert_client(True, *args)
+        return self._assert_client(True, *args)
 
     def assert_client_fails(self, *args):
         self._assert_client(False, *args)

--- a/test/client/test_python_client.py
+++ b/test/client/test_python_client.py
@@ -559,6 +559,28 @@ class CommandLineTest(ngamsTestSuite):
     def assert_client_fails(self, *args):
         self._assert_client(False, *args)
 
+    def test_client_information(self):
+        self.assert_client_succeeds('--license')
+        self.assert_client_succeeds('--version')
+
+    def test_client_status_document(self):
+        """Test the behavior of the -s flag of ngamsPClient"""
+
+        XML_DOC_START = b'<NgamsStatus>'
+        self.prepExtSrv()
+
+        out, _ = self.assert_client_succeeds('STATUS')
+        self.assertNotIn(XML_DOC_START, out, 'XML status document should not be printed')
+
+        out, _ = self.assert_client_succeeds('STATUS', '-s')
+        self.assertIn(XML_DOC_START, out, 'XML status document should be printed')
+
+        status_file = genTmpFilename()
+        out, _ = self.assert_client_succeeds('STATUS', '-s', status_file)
+        self.assertNotIn(XML_DOC_START, out, 'XML status document should not be printed')
+        with open(status_file, 'rb') as f:
+            self.assertIn(XML_DOC_START, f.read(), 'XML status document should be contained in file')
+
     def test_ars_success(self):
         """Happy paths for an archive/receive/subscribe commands"""
 


### PR DESCRIPTION
This set of changes improves the `-s` command line argument to take an optional file name. This has the effect of dumping the XML status document into that file instead of into `stdout`, which is still the behavior when `-s` is passed without a value.

There are also some other minor improvements, including unit testing of the new functionality and of the `--license` and `--version` command-line switches.