### PR TITLE
Ported partner sites feature from ALMA NGAS source code

### DIFF
--- a/src/ngamsServer/ngamsServer/commands/status.py
+++ b/src/ngamsServer/ngamsServer/commands/status.py
@@ -536,8 +536,6 @@ def handleCmd(srvObj,
                 raise Exception(errMsg)
             diskObj.addFileObj(fileObj)
             status.addDiskStatus(diskObj)
-            genDiskStatus = 1
-            genFileStatus = 1
         except:
             # The file was not found in the database. Check if it is available
             # on a remote partner site.
@@ -548,8 +546,8 @@ def handleCmd(srvObj,
             # Update status reply using the disk status and file status
             # information retrieved from the partner site
             status.addDiskStatus(disk_info)
-            genDiskStatus = 1
-            genFileStatus = 1
+        genDiskStatus = 1
+        genFileStatus = 1
     elif (requestId):
         logger.debug("Checking status of request with ID: %s", requestId)
         reqPropsObjRef = srvObj.getRequest(requestId)

--- a/src/ngamsServer/ngamsServer/commands/status.py
+++ b/src/ngamsServer/ngamsServer/commands/status.py
@@ -41,7 +41,7 @@ import types
 
 import six
 
-from ngamsLib.ngamsCore import NGAMS_HOST_LOCAL,\
+from ngamsLib.ngamsCore import NGAMS_HOST_LOCAL, NGAMS_HOST_REMOTE,\
     getHostName, genLog, genUniqueId, rmFile,\
     compressFile, NGAMS_GZIP_XML_MT, getNgamsVersion,\
     NGAMS_SUCCESS, NGAMS_XML_MT, fromiso8601, toiso8601
@@ -87,12 +87,23 @@ def _checkFileAccess(srvObj,
 
     # Check if the file is located on this host, or if the request should be
     # forwarded (if this server should act as proxy).
-    location, fileHost, ipAddress, filePortNo, mountPoint, filename, fileId,\
-              fileVersion, mimeType =\
-              ngamsFileUtils.locateArchiveFile(srvObj, fileId, fileVersion,
-                                               diskId)
+    try:
+        location, fileHost, ipAddress, filePortNo, mountPoint, filename, \
+        fileId, fileVersion, mimeType = \
+            ngamsFileUtils.locateArchiveFile(srvObj, fileId, fileVersion,
+                                             diskId, reqPropsObj=reqPropsObj)
+    except:
+        # If the file is still not found then try a remote partner site
+        location, fileHost, ipAddress, filePortNo, mountPoint, filename, \
+        fileId, fileVersion, mimeType = \
+            ngamsFileUtils.lookup_partner_site_file(srvObj, fileId,
+                                                    fileVersion, reqPropsObj)
 
-    if (location != NGAMS_HOST_LOCAL):
+    if location == NGAMS_HOST_REMOTE:
+        fileHost = "{0}:{1}".format(fileHost, filePortNo)
+        return genLog("NGAMS_INFO_FILE_AVAIL", [fileId + "/Version: " + str(fileVersion), fileHost])
+
+    elif location != NGAMS_HOST_LOCAL:
         # Go and get it!
         host, port = srvObj.get_remote_server_endpoint(fileHost)
         pars = (('file_access', fileId), ('file_version', fileVersion), ('disk_id', diskId))
@@ -387,8 +398,8 @@ def _handleFileListReply(srvObj,
 
 
 def handleCmd(srvObj,
-                    reqPropsObj,
-                    httpRef):
+              reqPropsObj,
+              httpRef):
     """
     Handle STATUS command.
 
@@ -403,12 +414,11 @@ def handleCmd(srvObj,
     Returns:        Void.
     """
     status = ngamsStatus.ngamsStatus()
-    status.\
-             setDate(toiso8601()).\
-             setVersion(getNgamsVersion()).setHostId(srvObj.getHostId()).\
-             setStatus(NGAMS_SUCCESS).\
-             setMessage("Successfully handled command STATUS").\
-             setState(srvObj.getState()).setSubState(srvObj.getSubState())
+    status.setDate(toiso8601()).\
+           setVersion(getNgamsVersion()).setHostId(srvObj.getHostId()).\
+           setStatus(NGAMS_SUCCESS).\
+           setMessage("Successfully handled command STATUS").\
+           setState(srvObj.getState()).setSubState(srvObj.getSubState())
 
     reqPropsObjRef = reqPropsObj
 
@@ -515,19 +525,31 @@ def handleCmd(srvObj,
         genDiskStatus = 1
     elif (fileId):
         if (not fileVersion): fileVersion = -1
-        fileObj = ngamsFileInfo.ngamsFileInfo()
-        fileObj.read(srvObj.getHostId(), srvObj.getDb(), fileId, fileVersion)
-        diskObj = ngamsDiskInfo.ngamsDiskInfo()
         try:
-            diskObj.read(srvObj.getDb(), fileObj.getDiskId())
+            fileObj = ngamsFileInfo.ngamsFileInfo()
+            fileObj.read(srvObj.getHostId(), srvObj.getDb(), fileId, fileVersion)
+            diskObj = ngamsDiskInfo.ngamsDiskInfo()
+            try:
+                diskObj.read(srvObj.getDb(), fileObj.getDiskId())
+            except:
+                errMsg = "Illegal Disk ID found: {0} for file with ID: {1}".format(fileObj.getDiskId(), fileId)
+                raise Exception(errMsg)
+            diskObj.addFileObj(fileObj)
+            status.addDiskStatus(diskObj)
+            genDiskStatus = 1
+            genFileStatus = 1
         except:
-            errMsg = "Illegal Disk ID found: %s for file with ID: %s" %\
-                     (fileObj.getDiskId(), fileId)
-            raise Exception(errMsg)
-        diskObj.addFileObj(fileObj)
-        status.addDiskStatus(diskObj)
-        genDiskStatus = 1
-        genFileStatus = 1
+            # The file was not found in the database. Check if it is available
+            # on a remote partner site.
+            host, port, status_info, disk_info, file_info = \
+                ngamsFileUtils.lookup_partner_site_file_status(srvObj, fileId,
+                                                               fileVersion,
+                                                               reqPropsObj)
+            # Update status reply using the disk status and file status
+            # information retrieved from the partner site
+            status.addDiskStatus(disk_info)
+            genDiskStatus = 1
+            genFileStatus = 1
     elif (requestId):
         logger.debug("Checking status of request with ID: %s", requestId)
         reqPropsObjRef = srvObj.getRequest(requestId)

--- a/src/ngamsServer/ngamsServer/ngamsFileUtils.py
+++ b/src/ngamsServer/ngamsServer/ngamsFileUtils.py
@@ -104,18 +104,22 @@ def lookup_partner_site_file_status(ngas_server,
 
     file_info:      Status response file information object (ngamsFileInfo)
     """
+    file_reference = file_id
+    if (file_version > 0):
+        file_reference += "/Version: " + str(file_version)
+
     # If the request came from a partner site. We will not continue to
     # propagate the request to avoid a death loop scenario. We will raise an
     # exception.
     if request_properties.hasHttpPar("partner_site_redirect"):
-        error_message = genLog("NGAMS_ER_UNAVAIL_FILE", [file_id])
+        error_message = genLog("NGAMS_ER_UNAVAIL_FILE", [file_reference])
         logger.debug(error_message)
         raise Exception(error_message)
 
     # Check partner sites is enabled are available from the configuration
     if not ngas_server.is_partner_sites_proxy_mode()\
             or not ngas_server.get_partner_sites_address_list():
-        error_message = genLog("NGAMS_ER_UNAVAIL_FILE", [file_id])
+        error_message = genLog("NGAMS_ER_UNAVAIL_FILE", [file_reference])
         logger.debug(error_message)
         raise Exception(error_message)
 
@@ -158,7 +162,7 @@ def lookup_partner_site_file_status(ngas_server,
 
     if status_info is None:
         # Failed to find file on a partner site
-        error_message = genLog("NGAMS_ER_UNAVAIL_FILE", [file_id])
+        error_message = genLog("NGAMS_ER_UNAVAIL_FILE", [file_reference])
         logger.debug(error_message)
         raise Exception(error_message)
 

--- a/src/ngamsServer/ngamsServer/ngamsFileUtils.py
+++ b/src/ngamsServer/ngamsServer/ngamsFileUtils.py
@@ -113,14 +113,12 @@ def lookup_partner_site_file_status(ngas_server,
     # exception.
     if request_properties.hasHttpPar("partner_site_redirect"):
         error_message = genLog("NGAMS_ER_UNAVAIL_FILE", [file_reference])
-        logger.debug(error_message)
         raise Exception(error_message)
 
     # Check partner sites is enabled are available from the configuration
     if not ngas_server.is_partner_sites_proxy_mode()\
             or not ngas_server.get_partner_sites_address_list():
         error_message = genLog("NGAMS_ER_UNAVAIL_FILE", [file_reference])
-        logger.debug(error_message)
         raise Exception(error_message)
 
     # Lets query the partner sites for the availability of the requested file
@@ -160,10 +158,9 @@ def lookup_partner_site_file_status(ngas_server,
             port = partner_port
             break
 
-    if status_info is None:
+    if status_info is None or status_info.getStatus() == "FAILURE":
         # Failed to find file on a partner site
         error_message = genLog("NGAMS_ER_UNAVAIL_FILE", [file_reference])
-        logger.debug(error_message)
         raise Exception(error_message)
 
     return host, port, status_info, disk_info, file_info

--- a/src/ngamsServer/ngamsServer/ngamsServer.py
+++ b/src/ngamsServer/ngamsServer/ngamsServer.py
@@ -63,8 +63,8 @@ from ngamsLib.ngamsCore import genLog, getNgamsVersion, \
     NGAMS_HTTP_REDIRECT, NGAMS_HTTP_INT_AUTH_USER, \
     NGAMS_SUCCESS, NGAMS_FAILURE, NGAMS_OFFLINE_STATE,\
     NGAMS_IDLE_SUBSTATE, NGAMS_BUSY_SUBSTATE, NGAMS_NOTIF_ERROR,\
-    NGAMS_NOT_SET, NGAMS_XML_MT, loadPlugInEntryPoint, isoTime2Secs,\
-    toiso8601
+    NGAMS_NOT_SET, NGAMS_XML_MT, NGAMS_RETRIEVE_CMD, loadPlugInEntryPoint,\
+    isoTime2Secs, toiso8601
 from ngamsLib import ngamsHighLevelLib, ngamsLib, ngamsEvent, ngamsHttpUtils,\
     utils, logutils
 from ngamsLib import ngamsDb, ngamsConfig, ngamsReqProps, pysendfile
@@ -438,8 +438,9 @@ class ngamsHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     def remote_proxy_request(self, request, host, port, timeout=300):
         """Proxy the current request to remote host ``host``:``port``"""
 
-        url = 'http://{0}:{1}/RETRIEVE'.format(host, port)
-        logger.info("Proxying request for /RETRIEVE to %s:%d", host, port)
+        url = 'http://{0}:{1}/{2}'.format(host, port, NGAMS_RETRIEVE_CMD)
+        logger.info("Proxying request for /%s to %s:%d", NGAMS_RETRIEVE_CMD,
+                    host, port)
 
         parameter_list = []
         for parameter in request.getHttpParNames():
@@ -495,6 +496,9 @@ class ngamsHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             data_sent += len(stream_buffer)
 
         elapsed_time = time.time() - start_time
+        # Avoid divide by zeros later on, let's say it took us 1 [us] to do this
+        if elapsed_time == 0:
+            elapsed_time = 0.000001
         size_mb = size / 1024. / 1024.
         logger.info("Sent data stream at %.3f [MB/s]", size_mb / elapsed_time)
 

--- a/src/ngamsServer/ngamsServer/ngamsServer.py
+++ b/src/ngamsServer/ngamsServer/ngamsServer.py
@@ -489,11 +489,15 @@ class ngamsHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         start_time = time.time()
 
         # TODO: Should we do something about https here?
-        self.wfile.flush()
         while data_sent < data_to_send:
             stream_buffer = response.read(block_size)
+            stream_buffer_size = len(stream_buffer)
             self.wfile.write(stream_buffer)
-            data_sent += len(stream_buffer)
+            data_sent += stream_buffer_size
+            if stream_buffer_size == 0 and data_sent < data_to_send:
+                logger.error("Data stream is incomplete. Only received %d bytes, expected %d bytes.",
+                             data_sent, data_to_send)
+                break
 
         elapsed_time = time.time() - start_time
         # Avoid divide by zeros later on, let's say it took us 1 [us] to do this

--- a/test/commands/test_archive.py
+++ b/test/commands/test_archive.py
@@ -1126,8 +1126,9 @@ class ngamsArchiveCmdTest(ngamsTestSuite):
         """
         ports = range(8001, 8005)
         cfg_file, cfg_props = self._genArchProxyCfg(ports)
-        self.prepExtSrv(port=8000, cfgFile=cfg_file, cfgProps=cfg_props)
-        self.prepCluster(ports, createDatabase = False)
+        sqlite_file = tmp_path('ngas.sqlite')
+        self.prepExtSrv(port=8000, cfgFile=cfg_file, cfgProps=cfg_props, sqlite_file=sqlite_file)
+        self.prepCluster(ports, createDatabase = False, sqlite_file=sqlite_file)
         noOfNodes = len(ports)
         nodeCount = 0
         counts = {p: 0 for p in ports}
@@ -1228,8 +1229,9 @@ class ngamsArchiveCmdTest(ngamsTestSuite):
         """
         ports = range(8001, 8005)
         cfg_file, cfg_props = self._genArchProxyCfg(ports)
-        _, dbObj = self.prepExtSrv(port=8000, cfgFile=cfg_file, cfgProps=cfg_props)
-        self.prepCluster(ports, createDatabase = False)
+        sqlite_file = tmp_path('ngas.sqlite')
+        _, dbObj = self.prepExtSrv(port=8000, cfgFile=cfg_file, cfgProps=cfg_props, sqlite_file=sqlite_file)
+        self.prepCluster(ports, createDatabase = False, sqlite_file=sqlite_file)
         # Set all Disks in unit <Host>:8002 to completed.
         dbObj.query2("UPDATE ngas_disks SET completed=1 WHERE host_id={0}", args=("%s:8002" % getHostName(),))
         # Set <Host>:8004 to Offline.

--- a/test/ngamsTestLib.py
+++ b/test/ngamsTestLib.py
@@ -879,7 +879,8 @@ class ngamsTestSuite(unittest.TestCase):
                    srvModule = None,
                    force=False,
                    daemon = False,
-                   cert_file=None):
+                   cert_file=None,
+                   sqlite_file=None):
         """
         Prepare a standard server object, which runs as a separate process and
         serves via the standard HTTP interface.
@@ -942,10 +943,16 @@ class ngamsTestSuite(unittest.TestCase):
 
         cfgObj = self.env_aware_cfg(cfgFile)
 
+        # Calculate root directory and clear if needed
+        root_dir = root_dir or tmp_path('NGAS')
+        if delDirs:
+            shutil.rmtree(root_dir, True)
+
         # Change what needs to be changed, like the position of the Sqlite
         # database file when necessary, the custom configuration items, and the
         # port number
-        self.point_to_sqlite_database(cfgObj, not dbCfgName and clearDb)
+        sqlite_file = sqlite_file or os.path.join(root_dir, 'ngas.sqlite')
+        self.point_to_sqlite_database(cfgObj, sqlite_file, create=(not dbCfgName and clearDb))
         if (cfgProps):
             for cfgProp in cfgProps:
                 # TODO: Handle Cfg. Group ID.
@@ -956,10 +963,7 @@ class ngamsTestSuite(unittest.TestCase):
 
         # Now connect to the database and perform any cleanups before we start
         # the server, like removing existing NGAS dirs and clearing tables
-        root_dir = root_dir or tmp_path('NGAS')
         dbObj = ngamsDb.from_config(cfgObj, maxpool=1)
-        if delDirs:
-            shutil.rmtree(root_dir, True)
         if (clearDb):
             logger.debug("Clearing NGAS DB ...")
             delNgasTbls(dbObj)
@@ -1422,7 +1426,7 @@ class ngamsTestSuite(unittest.TestCase):
         return [srvId, port, cfg, db]
 
     def prepCluster(self, server_list, cfg_file='src/ngamsCfg.xml', createDatabase=True,
-                    cfg_props=(), cert_file=None):
+                    cfg_props=(), cert_file=None, sqlite_file=None):
         """
         Prepare a common, simulated cluster. This consists of 1 to N
         servers running on the same node. It is ensured that each of
@@ -1457,7 +1461,8 @@ class ngamsTestSuite(unittest.TestCase):
 
         # Create the shared database first of all and generate a new config file
         tmpCfg = self.env_aware_cfg(cfg_file)
-        self.point_to_sqlite_database(tmpCfg, createDatabase)
+        sqlite_file = sqlite_file or tmp_path('ngas.sqlite')
+        self.point_to_sqlite_database(tmpCfg, sqlite_file, create=createDatabase)
         if createDatabase:
             with contextlib.closing(ngamsDb.from_config(tmpCfg, maxpool=1)) as db:
                 delNgasTbls(db)
@@ -1480,14 +1485,13 @@ class ngamsTestSuite(unittest.TestCase):
 
         return d
 
-    def point_to_sqlite_database(self, cfgObj, create):
+    def point_to_sqlite_database(self, cfgObj, sqlite_file, create=True):
         # Exceptional handling for SQLite.
         if 'sqlite' in cfgObj.getDbInterface().lower():
 
-            # sqlite_file = os.path.join(tmp_root, 'ngas.sqlite')
-            sqlite_file = genTmpFilename(suffix='.sqlite')
             if create:
                 rmFile(sqlite_file)
+                checkCreatePath(os.path.dirname(sqlite_file))
                 import sqlite3
                 fname = 'ngamsCreateTables-SQLite.sql'
                 script = utils.b2s(pkg_resources.resource_string('ngamsSql', fname))  # @UndefinedVariable

--- a/test/ngamsTestLib.py
+++ b/test/ngamsTestLib.py
@@ -1484,7 +1484,8 @@ class ngamsTestSuite(unittest.TestCase):
         # Exceptional handling for SQLite.
         if 'sqlite' in cfgObj.getDbInterface().lower():
 
-            sqlite_file = os.path.join(tmp_root, 'ngas.sqlite')
+            # sqlite_file = os.path.join(tmp_root, 'ngas.sqlite')
+            sqlite_file = genTmpFilename(suffix='.sqlite')
             if create:
                 rmFile(sqlite_file)
                 import sqlite3

--- a/test/test_config_handling.py
+++ b/test/test_config_handling.py
@@ -40,7 +40,7 @@ import unittest
 
 from ngamsLib import ngamsConfig, ngamsDb, ngamsXmlMgr
 from .ngamsTestLib import delNgasTbls, ngamsTestSuite, \
-    save_to_tmp
+    save_to_tmp, tmp_path
 
 
 dbIdAttr = 'Db-Test'
@@ -130,7 +130,7 @@ class ngamsConfigHandlingTest(ngamsTestSuite):
         revAttr = "NgamsCfg.Header[1].Revision"
         cfgObj.storeVal(revAttr, "TEST-REVISION", "ngamsCfg-Test")
 
-        self.point_to_sqlite_database(cfgObj, createDatabase)
+        self.point_to_sqlite_database(cfgObj, tmp_path('ngas.sqlite'), create=createDatabase)
         dbObj = ngamsDb.from_config(cfgObj, maxpool=1)
         if (delDbTbls): delNgasTbls(dbObj)
         cfgObj.writeToDb(dbObj)

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -28,7 +28,7 @@ class DbTests(ngamsTestLib.ngamsTestSuite):
     def setUp(self):
         super(DbTests, self).setUp()
         cfg = self.env_aware_cfg()
-        self.point_to_sqlite_database(cfg, True)
+        self.point_to_sqlite_database(cfg, ngamsTestLib.tmp_path('ngas.sqlite'))
         self.db = ngamsDb.from_config(cfg, maxpool=1)
         ngamsTestLib.delNgasTbls(self.db)
 

--- a/test/test_partner_sites.py
+++ b/test/test_partner_sites.py
@@ -1,0 +1,124 @@
+#
+#    ALMA - Atacama Large Millimiter Array
+#    (c) European Southern Observatory, 2002
+#    Copyright by ESO (in the framework of the ALMA collaboration),
+#    All rights reserved
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+#    MA 02111-1307  USA
+#
+
+"""
+This module contains the Test Suite for the partner sites feature.
+"""
+
+import contextlib
+import functools
+import os
+
+from ngamsLib import ngamsHttpUtils, ngamsStatus
+from ngamsLib.ngamsCore import getHostName
+from .ngamsTestLib import ngamsTestSuite, tmp_path
+
+class NgasPartnerSiteTest(ngamsTestSuite):
+    """
+    Synopsis:
+    Test the partner site feature.
+
+    Description:
+    NGAS offers a partner site feature for proxy requests to remote NGAS hosts
+
+    Missing Test Cases:
+    """
+
+    def _prepare_partner_site_cluster(self, *original_server_list, **kwargs):
+        server_list = []
+        for server_info in original_server_list:
+            port, property_list = server_info[0], list(server_info[1])
+            server_list.append((port, property_list))
+
+        return self.prepCluster(server_list)
+
+    def test_archive_status_retrieve_sequence(self):
+        host_name = getHostName()
+        sample_file_name = "SmallFile.fits"
+        sample_file_path = os.path.join("src", sample_file_name)
+#        sample_file_size = os.path.getsize(sample_file_path)
+        sample_mime_type = "application/octet-stream"
+
+        # We create two cluster each container two NGAS nodes
+        # We configure the first cluster to use the second cluster as a partner site
+        config_list_1 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas1"),
+                         ("NgamsCfg.PartnerSites[1].ProxyMode", "1"),
+                         ("NgamsCfg.PartnerSites[1].PartnerSite[1].Address", "localhost:9011")]
+        self._prepare_partner_site_cluster((9001, config_list_1))
+
+        config_list_2 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas2")]
+        self._prepare_partner_site_cluster((9011, config_list_2))
+
+        # We archive a test sample file on the partner site cluster
+        self.archive(9011, sample_file_path, mimeType=sample_mime_type)
+
+        # We check the status of a file ID found on the partner site cluster
+        command_status = functools.partial(ngamsHttpUtils.httpGet, "localhost", 9001, "STATUS", timeout=5)
+        argument_list = {"file_id": sample_file_name}
+        with contextlib.closing(command_status(pars=argument_list)) as response:
+            self.assertEqual(response.status, 200)
+            # Parse the response XML status information
+            response_data = response.read()
+            status_info = ngamsStatus.ngamsStatus().unpackXmlDoc(response_data, 1)
+            disk_info = status_info.getDiskStatusList()[0]
+            file_info = disk_info.getFileObjList()[0]
+            self.assertEqual(disk_info.getHostId(), "{0}:9011".format(host_name))
+            self.assertEqual(file_info.getFileId(), sample_file_name)
+            self.assertEqual(file_info.getFileVersion(), 1)
+            self.assertEqual(file_info.getFormat(), sample_mime_type)
+
+        # Retrieve a file found on the partner site cluster
+        retrieve_file_path = tmp_path(sample_file_name)
+        self.retrieve(9001, sample_file_name, targetFile=retrieve_file_path)
+#        retrieve_file_size = os.path.getsize(retrieve_file_path)
+#        self.assertEqual(sample_file_size, retrieve_file_size)
+
+    def test_status_retrieve_sequence(self):
+        sample_file_name = "SmallFile.fits"
+        sample_file_path = os.path.join("src", sample_file_name)
+        bad_file_name = "dummy.fits"
+
+        # We create two cluster each container two NGAS nodes
+        # We configure the first cluster to use the second cluster as a partner site
+        config_list_1 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas1"),
+                         ("NgamsCfg.PartnerSites[1].ProxyMode", "1"),
+                         ("NgamsCfg.PartnerSites[1].PartnerSite[1].Address", "localhost:9011")]
+        self._prepare_partner_site_cluster((9001, config_list_1))
+
+        config_list_2 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas2")]
+        self._prepare_partner_site_cluster((9011, config_list_2))
+
+        # We check the status of a file ID found on the partner site cluster
+        command_status = functools.partial(ngamsHttpUtils.httpGet, "localhost", 9001, "STATUS", timeout=1000)
+        argument_list = {"file_id": bad_file_name}
+        with contextlib.closing(command_status(pars=argument_list)) as response:
+            self.assertEqual(response.status, 400)
+            # Parse the response XML status information
+            response_data = response.read()
+            status_info = ngamsStatus.ngamsStatus().unpackXmlDoc(response_data, 1)
+            self.assertEqual(status_info.getStatus(), "FAILURE")
+            self.assertEqual(status_info.getMessage(),
+                             "NGAMS_ER_UNAVAIL_FILE:4019:ERROR: File with ID: dummy.fits appears not to be available.")
+
+        # Retrieve a file found on the partner site cluster
+        retrieve_file_path = tmp_path(bad_file_name)
+        self.retrieve(9001, bad_file_name, targetFile=retrieve_file_path, expectedStatus='FAILURE')


### PR DESCRIPTION
This is the partner sites feature that was developed and used by the ALMA observatory. It is very useful and important feature for every day ALMA use in development and testing. It is also useful in production.

I cleaned up the code and refactored it so it is much cleaner than it was on the older NGAS code base. Please let me know if there are any further improvements I can make.

Update:
I forgot to say that the partner site feature is enabled in the NGAS XML configuration by adding the following element...
```
    <!--
        Partner Sites

        List of alternative NGAS servers belonging to separate NGAS archive
        installations. When a request to retrieve a file cannot be found on
        the local NGAS archive the request is redirected to the NGAS servers
        included in the partner sites list. The ProxyMode attribute can be
        used to enable/disable partner sites.
    -->
    <PartnerSites ProxyMode="1">
        <PartnerSite Address="http://ngas01.example.com:8080"/>
    </PartnerSites>
```