### PR TITLE
Fixed redirect bug in partner sites

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -72,6 +72,9 @@ Changelog
 * Removing the ``create_venv.sh`` script from the sources,
   in favour of letting users create one by themselves if they want,
   or let the fabric tasks create one.
+* Added new partner sites feature that provides the capability of configuring
+  a remote NGAS cluster as a proxy for retrieving files that are not available
+  in the local NGAS cluster.
 
 .. rubric:: 11.0.2
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -563,3 +563,16 @@ are a comma-separated key=value parameter pairs:
    (see :ref:`server.states`).
  * *DiskSyncPlugIn* and *DiskSyncPlugInPars*:
    The plug-in used to perform a full disk sync.
+
+PartnerSites
+------------
+
+The ``PartnerSites`` element defines a list of alternative
+(remote) NGAS servers belonging to separate NGAS archive
+installations. When a request to retrieve a file cannot be
+found on the local NGAS archive the request is redirected
+to the NGAS servers included in the partner sites list.
+The ``ProxyMode`` attribute can be used to enable/disable
+partner sites.
+Several ``PartnerSite`` child elements can be added containing
+the ``Address`` attribute for the remote NGAS server address.

--- a/src/ngamsServer/ngamsServer/ngamsFileUtils.py
+++ b/src/ngamsServer/ngamsServer/ngamsFileUtils.py
@@ -89,15 +89,12 @@ def parse_host_id(host_id):
 
     port:           NGAS server port number
     """
-    try:
-        host = host_id.split(":")[0]
-        domain = None
-        if "." in host:
-            domain = host.split(".", 1)[-1]
-        port = int(host_id.split(":")[-1])
-        return host, domain, port
-    except IndexError:
-        return None, None, None
+    host = host_id.split(":")[0]
+    domain = None
+    if "." in host:
+        domain = host.split(".", 1)[-1]
+    port = int(host_id.split(":")[-1])
+    return host, domain, port
 
 
 def lookup_partner_site_file_status(ngas_server,

--- a/src/ngamsServer/ngamsServer/ngamsFileUtils.py
+++ b/src/ngamsServer/ngamsServer/ngamsFileUtils.py
@@ -185,7 +185,7 @@ def lookup_partner_site_file_status(ngas_server,
             # the partner site address. This should work because they are
             # part of the same cluster.
             host, domain, port = parse_host_id(disk_info.getHostId())
-            if domain is None:
+            if domain is None and partner_domain is not None:
                 host = host + "." + partner_domain
             break
 

--- a/src/ngamsServer/ngamsServer/ngamsFileUtils.py
+++ b/src/ngamsServer/ngamsServer/ngamsFileUtils.py
@@ -73,6 +73,33 @@ logger = logging.getLogger(__name__)
 checksum_info = collections.namedtuple('crc_info', 'init method final from_bytes equals')
 
 
+def parse_host_id(host_id):
+    """
+    Parses an NGAS server host ID containing '<hostname>:<port>'
+
+    Parameters:
+
+    host_id:        NGAS server host ID
+
+    Returns:
+
+    host:           NGAS server host name (or IP address)
+
+    domain:         NGAS server domain name (or IP address)
+
+    port:           NGAS server port number
+    """
+    try:
+        host = host_id.split(":")[0]
+        domain = None
+        if "." in host:
+            domain = host.split(".", 1)[-1]
+        port = int(host_id.split(":")[-1])
+        return host, domain, port
+    except IndexError:
+        return None, None, None
+
+
 def lookup_partner_site_file_status(ngas_server,
                                     file_id,
                                     file_version,
@@ -130,8 +157,7 @@ def lookup_partner_site_file_status(ngas_server,
 
     host, port, status_info, disk_info, file_info = None, None, None, None, None
     for partner_site in ngas_server.get_partner_sites_address_list():
-        partner_address = partner_site.split(":")[0]
-        partner_port = int(partner_site.split(":")[-1])
+        partner_address, partner_domain, partner_port = parse_host_id(partner_site)
         try:
             logger.info("Looking up file ID %s on partner site %s", file_id,
                         partner_site)
@@ -154,8 +180,13 @@ def lookup_partner_site_file_status(ngas_server,
             logger.info(genLog("NGAMS_INFO_FILE_AVAIL", [file_id, partner_address]))
             disk_info = status_info.getDiskStatusList()[0]
             file_info = disk_info.getFileObjList()[0]
-            host = partner_address
-            port = partner_port
+            # This is a bit of a hack because the host ID may not contain
+            # the fully qualified address. We append the domain name from
+            # the partner site address. This should work because they are
+            # part of the same cluster.
+            host, domain, port = parse_host_id(disk_info.getHostId())
+            if domain is None:
+                host = host + "." + partner_domain
             break
 
     if status_info is None or status_info.getStatus() == "FAILURE":

--- a/src/ngamsServer/ngamsServer/ngamsServer.py
+++ b/src/ngamsServer/ngamsServer/ngamsServer.py
@@ -452,10 +452,14 @@ class ngamsHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         start_byte = 0
         header_list = []
         for header in request.getHttpHdrs():
-            header_list.append([header, request.getHttpHdr(header)])
             if header.lower() == "range":
                 value = request.getHttpHdr(header)
                 start_byte = int(value.replace("bytes=", "").split("-")[0])
+            if header.lower() == "host":
+                # Update the host to the partner site server
+                header_list.append(["host", "{0}:{1}".format(host, port)])
+            else:
+                header_list.append([header, request.getHttpHdr(header)])
 
         block_size = self.ngasServer.getCfg().getBlockSize()
 

--- a/test/test_partner_sites.py
+++ b/test/test_partner_sites.py
@@ -30,6 +30,7 @@ import os
 
 from ngamsLib import ngamsHttpUtils, ngamsStatus
 from ngamsLib.ngamsCore import getHostName
+from ngamsServer import ngamsFileUtils
 from .ngamsTestLib import ngamsTestSuite, tmp_path
 
 class NgasPartnerSiteTest(ngamsTestSuite):
@@ -50,6 +51,13 @@ class NgasPartnerSiteTest(ngamsTestSuite):
             server_list.append((port, property_list))
 
         return self.prepCluster(server_list)
+
+    def test_parse_host_id(self):
+        host_id = "ngas.example.com:7777"
+        host_name, domain_name, port = ngamsFileUtils.parse_host_id(host_id)
+        self.assertEqual(host_name, "ngas.example.com")
+        self.assertEqual(domain_name, "example.com")
+        self.assertEqual(port, 7777)
 
     def test_archive_status_retrieve_sequence(self):
 

--- a/test/test_partner_sites.py
+++ b/test/test_partner_sites.py
@@ -94,7 +94,7 @@ class NgasPartnerSiteTest(ngamsTestSuite):
         self.archive(9011, sample_file_path, mimeType=sample_mime_type)
 
         # We check the status of a file ID found on the partner site cluster
-        command_status = functools.partial(ngamsHttpUtils.httpGet, host_name, 9001, "STATUS", timeout=5)
+        command_status = functools.partial(ngamsHttpUtils.httpGet, "localhost", 9001, "STATUS", timeout=5)
         argument_list = {"file_id": sample_file_name}
         with contextlib.closing(command_status(pars=argument_list)) as response:
             self.assertEqual(response.status, 200)
@@ -139,7 +139,7 @@ class NgasPartnerSiteTest(ngamsTestSuite):
         self._prepare_partner_site_cluster((9011, config_list_2))
 
         # We check the status of a file ID found on the partner site cluster
-        command_status = functools.partial(ngamsHttpUtils.httpGet, host_name, 9001, "STATUS", timeout=1000)
+        command_status = functools.partial(ngamsHttpUtils.httpGet, "localhost", 9001, "STATUS", timeout=1000)
         argument_list = {"file_id": bad_file_name}
         with contextlib.closing(command_status(pars=argument_list)) as response:
             self.assertEqual(response.status, 400)

--- a/test/test_partner_sites.py
+++ b/test/test_partner_sites.py
@@ -30,6 +30,7 @@ import os
 
 from ngamsLib import ngamsHttpUtils, ngamsStatus
 from ngamsLib.ngamsCore import getHostName
+from ngamsLib.ngamsLib import getDomain
 from ngamsServer import ngamsFileUtils
 from .ngamsTestLib import ngamsTestSuite, tmp_path
 
@@ -66,6 +67,8 @@ class NgasPartnerSiteTest(ngamsTestSuite):
             self.skipTest("This test works only against the sqlite db")
 
         host_name = getHostName()
+        domain_name = getDomain()
+        host_name_fqdn = "{0}.{1}".format(host_name, domain_name)
         sample_file_name = "SmallFile.fits"
         sample_file_path = os.path.join("src", sample_file_name)
 #        sample_file_size = os.path.getsize(sample_file_path)
@@ -73,19 +76,22 @@ class NgasPartnerSiteTest(ngamsTestSuite):
 
         # We create two cluster each container two NGAS nodes
         # We configure the first cluster to use the second cluster as a partner site
+        partner_host_id = "{0}:9011".format(host_name_fqdn)
         config_list_1 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas1"),
+                         ("NgamsCfg.Server[1].IpAddress", "0.0.0.0"),
                          ("NgamsCfg.PartnerSites[1].ProxyMode", "1"),
-                         ("NgamsCfg.PartnerSites[1].PartnerSite[1].Address", "localhost:9011")]
+                         ("NgamsCfg.PartnerSites[1].PartnerSite[1].Address", partner_host_id)]
         self._prepare_partner_site_cluster((9001, config_list_1))
 
-        config_list_2 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas2")]
+        config_list_2 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas2"),
+                         ("NgamsCfg.Server[1].IpAddress", "0.0.0.0")]
         self._prepare_partner_site_cluster((9011, config_list_2))
 
         # We archive a test sample file on the partner site cluster
         self.archive(9011, sample_file_path, mimeType=sample_mime_type)
 
         # We check the status of a file ID found on the partner site cluster
-        command_status = functools.partial(ngamsHttpUtils.httpGet, "localhost", 9001, "STATUS", timeout=5)
+        command_status = functools.partial(ngamsHttpUtils.httpGet, host_name, 9001, "STATUS", timeout=5)
         argument_list = {"file_id": sample_file_name}
         with contextlib.closing(command_status(pars=argument_list)) as response:
             self.assertEqual(response.status, 200)
@@ -106,22 +112,28 @@ class NgasPartnerSiteTest(ngamsTestSuite):
 #        self.assertEqual(sample_file_size, retrieve_file_size)
 
     def test_status_retrieve_sequence(self):
+        host_name = getHostName()
+        domain_name = getDomain()
+        host_name_fqdn = "{0}.{1}".format(host_name, domain_name)
         sample_file_name = "SmallFile.fits"
         sample_file_path = os.path.join("src", sample_file_name)
         bad_file_name = "dummy.fits"
 
         # We create two cluster each container two NGAS nodes
         # We configure the first cluster to use the second cluster as a partner site
+        partner_host_id = "{0}:9011".format(host_name_fqdn)
         config_list_1 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas1"),
+                         ("NgamsCfg.Server[1].IpAddress", "0.0.0.0"),
                          ("NgamsCfg.PartnerSites[1].ProxyMode", "1"),
-                         ("NgamsCfg.PartnerSites[1].PartnerSite[1].Address", "localhost:9011")]
+                         ("NgamsCfg.PartnerSites[1].PartnerSite[1].Address", partner_host_id)]
         self._prepare_partner_site_cluster((9001, config_list_1))
 
-        config_list_2 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas2")]
+        config_list_2 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas2"),
+                         ("NgamsCfg.Server[1].IpAddress", "0.0.0.0")]
         self._prepare_partner_site_cluster((9011, config_list_2))
 
         # We check the status of a file ID found on the partner site cluster
-        command_status = functools.partial(ngamsHttpUtils.httpGet, "localhost", 9001, "STATUS", timeout=1000)
+        command_status = functools.partial(ngamsHttpUtils.httpGet, host_name, 9001, "STATUS", timeout=1000)
         argument_list = {"file_id": bad_file_name}
         with contextlib.closing(command_status(pars=argument_list)) as response:
             self.assertEqual(response.status, 400)

--- a/test/test_partner_sites.py
+++ b/test/test_partner_sites.py
@@ -79,7 +79,7 @@ class NgasPartnerSiteTest(ngamsTestSuite):
         # We create two NGAS clusters each containing a single NGAS node
         # We configure the first NGAS cluster to use the second NGAS cluster
         # as a partner site
-        partner_host_id = "{0}:9011".format(host_name_fqdn)
+        partner_host_id = "{0}:9011".format("localhost")
         config_list_1 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas1"),
                          ("NgamsCfg.Server[1].IpAddress", "0.0.0.0"),
                          ("NgamsCfg.PartnerSites[1].ProxyMode", "1"),
@@ -127,7 +127,7 @@ class NgasPartnerSiteTest(ngamsTestSuite):
         # We create two NGAS clusters each containing a single NGAS node
         # We configure the first NGAS cluster to use the second NGAS cluster
         # as a partner site
-        partner_host_id = "{0}:9011".format(host_name_fqdn)
+        partner_host_id = "{0}:9011".format("localhost")
         config_list_1 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas1"),
                          ("NgamsCfg.Server[1].IpAddress", "0.0.0.0"),
                          ("NgamsCfg.PartnerSites[1].ProxyMode", "1"),

--- a/test/test_partner_sites.py
+++ b/test/test_partner_sites.py
@@ -68,14 +68,17 @@ class NgasPartnerSiteTest(ngamsTestSuite):
 
         host_name = getHostName()
         domain_name = getDomain()
-        host_name_fqdn = "{0}.{1}".format(host_name, domain_name)
+        host_name_fqdn = host_name
+        if domain_name is not None:
+            host_name_fqdn = "{0}.{1}".format(host_name, domain_name)
         sample_file_name = "SmallFile.fits"
         sample_file_path = os.path.join("src", sample_file_name)
 #        sample_file_size = os.path.getsize(sample_file_path)
         sample_mime_type = "application/octet-stream"
 
-        # We create two cluster each container two NGAS nodes
-        # We configure the first cluster to use the second cluster as a partner site
+        # We create two NGAS clusters each containing a single NGAS node
+        # We configure the first NGAS cluster to use the second NGAS cluster
+        # as a partner site
         partner_host_id = "{0}:9011".format(host_name_fqdn)
         config_list_1 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas1"),
                          ("NgamsCfg.Server[1].IpAddress", "0.0.0.0"),
@@ -114,13 +117,16 @@ class NgasPartnerSiteTest(ngamsTestSuite):
     def test_status_retrieve_sequence(self):
         host_name = getHostName()
         domain_name = getDomain()
-        host_name_fqdn = "{0}.{1}".format(host_name, domain_name)
-        sample_file_name = "SmallFile.fits"
-        sample_file_path = os.path.join("src", sample_file_name)
+        host_name_fqdn = host_name
+        if domain_name is not None:
+            host_name_fqdn = "{0}.{1}".format(host_name, domain_name)
+#        sample_file_name = "SmallFile.fits"
+#        sample_file_path = os.path.join("src", sample_file_name)
         bad_file_name = "dummy.fits"
 
-        # We create two cluster each container two NGAS nodes
-        # We configure the first cluster to use the second cluster as a partner site
+        # We create two NGAS clusters each containing a single NGAS node
+        # We configure the first NGAS cluster to use the second NGAS cluster
+        # as a partner site
         partner_host_id = "{0}:9011".format(host_name_fqdn)
         config_list_1 = [("NgamsCfg.Server[1].RootDirectory", "/tmp/ngas1"),
                          ("NgamsCfg.Server[1].IpAddress", "0.0.0.0"),


### PR DESCRIPTION
There was a bug in the partner sites feature. It was largely down to a misunderstanding on my part. I thought the partner site server should act as a proxy but instead we should stream the file directly from where it is hosted.
I also added a new function to parse the host ID. Perhaps one already exists. If so I can remove it and reuse the existing function.