### PR TITLE
Added exclude commands feature to authorization

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -72,6 +72,8 @@ Changelog
 * Removing the ``create_venv.sh`` script from the sources,
   in favour of letting users create one by themselves if they want,
   or let the fabric tasks create one.
+* Added `Exclude` attribute to the `Authorization` element for defining
+  a list of commands that are to be excluded from authorization
 
 .. rubric:: 11.0.2
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -479,6 +479,9 @@ For details see :ref:`server.authorization`.
 The ``Authorization`` element has an ``Enable`` attribute
 which determines whether authentication and authorization
 is enabled (``1``) or not (``0``).
+The ``Authorization`` element also has an ``Exclude`` attribute
+for defining a list of commands that are to be excluded from
+authoriztion.
 Zero or more ``User`` XML sub-elements
 also describe a different user recognized by NGAS.
 Each ``User`` element should have the following attributes:

--- a/src/ngamsCore/ngamsLib/ngamsConfig.py
+++ b/src/ngamsCore/ngamsLib/ngamsConfig.py
@@ -1648,7 +1648,6 @@ class ngamsConfig:
         par = "FileStagingDef[1].PlugIn"
         return self.getVal(par)
 
-
     def getAuthorize(self):
         """
         Return the authorization flag.
@@ -1658,6 +1657,20 @@ class ngamsConfig:
         par = "Authorization[1].Enable"
         return getInt(par, self.getVal(par))
 
+    def getAuthExcludeCommandList(self):
+        """
+        Return the list of commands excluded from authorization
+
+        Returns:    comma separated commands (string).
+                    e.g. ARCHIVE,CHECKFILE,RETRIEVE,STATUS
+                    A "*" is a wildcard for all commands
+        """
+        attribute = "Authorization[1].Exclude"
+        exclude_commands = self.getVal(attribute)
+        if exclude_commands is not None:
+            return exclude_commands.split(",")
+        else:
+            return None
 
     def addAuthUser(self,
                     user,

--- a/src/ngamsServer/ngamsServer/ngamsAuthUtils.py
+++ b/src/ngamsServer/ngamsServer/ngamsAuthUtils.py
@@ -64,11 +64,29 @@ def cmdPermitted(cfg, reqPropsObj, reqUser):
     return reqPropsObj.getCmd().strip() in commands.split(',')
 
 
+def isCommandExcluded(cfg, command):
+    """Check if the requested command is excluded from authorization"""
+
+    exclude_command_list = cfg.getAuthExcludeCommandList()
+    if exclude_command_list is None:
+        return False
+    if "*" in exclude_command_list or command in exclude_command_list:
+        return True
+    return False
+
+
 def authorize(cfg, reqPropsObj):
     """Check if the request is authorized for the authenticated user, if any"""
 
     if not cfg.getAuthorize():
         logger.debug("Authorization is disabled, continuing anonymously")
+        return
+
+    # Check if the requested command is excluded from authorization
+    requested_command = reqPropsObj.getCmd().strip()
+    if isCommandExcluded(cfg, requested_command):
+        logger.debug("Authorization is disabled for the '%s' command, continuing anonymously",
+                     requested_command)
         return
 
     # For now only Basic HTTP Authentication is implemented.


### PR DESCRIPTION
This feature would be useful for ALMA as we have lots of existing software interfacing with NGAS. It would difficult adding support for authorization to all of them all in one go. This feature would allow us to improve security gradually.

Oh, and this time I made sure I added a unit test :)
