### PR TITLE
Partner sites

### DIFF
--- a/src/ngamsServer/ngamsServer/ngamsServer.py
+++ b/src/ngamsServer/ngamsServer/ngamsServer.py
@@ -449,12 +449,8 @@ class ngamsHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             else:
                 parameter_list.append([parameter, request.getHttpPar(parameter)])
 
-        start_byte = 0
         header_list = []
         for header in request.getHttpHdrs():
-            if header.lower() == "range":
-                value = request.getHttpHdr(header)
-                start_byte = int(value.replace("bytes=", "").split("-")[0])
             if header.lower() == "host":
                 # Update the host to the partner site server
                 header_list.append(["host", "{0}:{1}".format(host, port)])
@@ -477,7 +473,7 @@ class ngamsHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
         with contextlib.closing(response):
             size = int(response.getheader("content-length"))
-            self.write_stream_data(response, response_headers, size, start_byte, block_size)
+            self.write_stream_data(response, response_headers, size, 0, block_size)
 
     def write_stream_data(self, response, headers, size, start_byte=0, block_size=65536):
         """Streams the data from the remote host"""

--- a/test/test_partner_sites.py
+++ b/test/test_partner_sites.py
@@ -68,7 +68,7 @@ class NgasPartnerSiteTest(ngamsTestSuite):
 
         host_name = getHostName()
         sample_file_name = "SmallFile.fits"
-        sample_file_path = os.path.join("src", sample_file_name)
+        sample_file_path = self.resource(os.path.join("src", sample_file_name))
         sample_file_size = os.path.getsize(sample_file_path)
         sample_mime_type = "application/octet-stream"
 

--- a/test/test_partner_sites.py
+++ b/test/test_partner_sites.py
@@ -67,13 +67,9 @@ class NgasPartnerSiteTest(ngamsTestSuite):
             self.skipTest("This test works only against the sqlite db")
 
         host_name = getHostName()
-        domain_name = getDomain()
-        host_name_fqdn = host_name
-        if domain_name is not None:
-            host_name_fqdn = "{0}.{1}".format(host_name, domain_name)
         sample_file_name = "SmallFile.fits"
         sample_file_path = os.path.join("src", sample_file_name)
-#        sample_file_size = os.path.getsize(sample_file_path)
+        sample_file_size = os.path.getsize(sample_file_path)
         sample_mime_type = "application/octet-stream"
 
         # We create two NGAS clusters each containing a single NGAS node
@@ -111,17 +107,17 @@ class NgasPartnerSiteTest(ngamsTestSuite):
         # Retrieve a file found on the partner site cluster
         retrieve_file_path = tmp_path(sample_file_name)
         self.retrieve(9001, sample_file_name, targetFile=retrieve_file_path)
-#        retrieve_file_size = os.path.getsize(retrieve_file_path)
-#        self.assertEqual(sample_file_size, retrieve_file_size)
+        retrieve_file_size = os.path.getsize(retrieve_file_path)
+        self.assertEqual(sample_file_size, retrieve_file_size)
+
+        # Retrieve a file with a 100 bytes offset
+        headers = {"range": "bytes=100-"}
+        self.retrieve(9001, sample_file_name, targetFile=retrieve_file_path, hdrs=headers)
+        retrieve_file_size = os.path.getsize(retrieve_file_path)
+        self.assertEqual(sample_file_size - 100, retrieve_file_size)
+
 
     def test_status_retrieve_sequence(self):
-        host_name = getHostName()
-        domain_name = getDomain()
-        host_name_fqdn = host_name
-        if domain_name is not None:
-            host_name_fqdn = "{0}.{1}".format(host_name, domain_name)
-#        sample_file_name = "SmallFile.fits"
-#        sample_file_path = os.path.join("src", sample_file_name)
         bad_file_name = "dummy.fits"
 
         # We create two NGAS clusters each containing a single NGAS node


### PR DESCRIPTION
After some tests we found that the range requests was broken. It would appear that we do not need to calculate the start byte (offset) when resuming a retrieve request. I have updated the unit tests to handle this scenario.