### PR TITLE
Fix subscription from config

### DIFF
--- a/src/ngamsCore/ngamsSql/ngamsCreateTables-Oracle.sql
+++ b/src/ngamsCore/ngamsSql/ngamsCreateTables-Oracle.sql
@@ -184,12 +184,10 @@ create table ngas_subscribers
     subscr_filter_plugin varchar2(64) null,
     subscr_filter_plugin_pars varchar2(128) null,
     last_file_ingestion_date varchar2(23) null,
-    concurrent_threads number(*, 0) default 1 null,
-    constraint pk_ngas_subscribers primary key (host_id, srv_port)
+    concurrent_threads number(*, 0) default 1 null
 );
 
 create unique index idx_ngas_subscribers_subscr_id on ngas_subscribers (subscr_id);
---create unique index idx_ngas_subscribers_host_id_srv_port on ngas_subscribers (host_id, srv_port);
 
 --Check the primary key is correct for this table
 create table ngas_subscr_back_log

--- a/src/ngamsServer/ngamsServer/ngamsSrvUtils.py
+++ b/src/ngamsServer/ngamsServer/ngamsSrvUtils.py
@@ -83,7 +83,7 @@ def _create_remote_subscriptions(srvObj, stop_evt):
     """
 
     subscriptions_in_cfg = srvObj.cfg.getSubscriptionsDic()
-    subscriptions = [v for _,v in subscriptions_in_cfg.items()]
+    subscriptions = [v for _, v in subscriptions_in_cfg.items()]
     subscriptions_created = 0
 
     while True:
@@ -115,7 +115,7 @@ def _create_remote_subscriptions(srvObj, stop_evt):
             url = 'http://%s:%d/%s' % (our_host, our_port, subscrObj.getUrl() or 'QARCHIVE')
             logger.info("Creating subscription to %s:%d with url=%s", subs_host, subs_port, url)
 
-            pars = [["subscr_id", url],
+            pars = [["subscr_id", subscrObj.getId()],
                     ["priority", subscrObj.getPriority()],
                     ["url",      url],
                     ["start_date", toiso8601(local=True)]]
@@ -221,7 +221,7 @@ def handleOnline(srvObj,
 
     # TODO: unify this "db-to-object" reading (there is something similar elsewhere,
     #       I'm pretty sure, and hide these low-level details from here
-    logger.info("Creating %d subscrption objects from subscription DB info", len(subscrList))
+    logger.info("Creating %d subscription objects from subscription DB info", len(subscrList))
     for subscrInfo in subscrList:
         start_date = fromiso8601(subscrInfo[5], local=True) if subscrInfo[5] else None
         last_ingested_date = fromiso8601(subscrInfo[8], local=True) if subscrInfo[8] else None


### PR DESCRIPTION
I removed a primary key from the Oracle SQL script. This should never have been included. I saw it on the old code base and thought it was probably a good thing. It was a bad choice on my part.

I fixed the subscribe ID bug. A trivial change. The unit tests pass OK. I was tempted to do more but I thought it best to stop there.