### PR TITLE
Mirroring plugin code cleanup

### DIFF
--- a/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
@@ -19,7 +19,7 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
-#******************************************************************************
+# *****************************************************************************
 #
 # "@(#) $Id: ngamsAlmaMultipart.py,v 1.3 2008/08/19 20:51:50 jknudstr Exp $"
 #
@@ -28,186 +28,125 @@
 # awicenec  2004/10/01  Created
 #
 """
-This Data Archiving Plug-In is used to handle reception and processing
-of ALMA multipart related message files containing ALMA UIDs.
+This Data Archiving Plug-In is used to handle reception and processing of ALMA multipart related message files
+containing ALMA UIDs.
 
-Note, that the plug-in is implemented for the usage for ALMA. If used in other
-contexts, a dedicated plug-in matching the individual context should be
-implemented and NG/AMS configured to use it.
+Note that the plug-in is implemented for the usage for ALMA. If used in other contexts, a dedicated plug-in matching
+the individual context should be implemented and NG/AMS configured to use it.
 """
 
+import email
 import logging
 import os
+import re
+import sys
 
 from ngamsLib import ngamsPlugInApi
-from ngamsLib.ngamsCore import genLog, toiso8601, FMT_DATE_ONLY
+from ngamsLib import ngamsCore
+from ngamsLib.ngamsCore import genLog
 
+PLUGIN_ID = __name__
+
+# This matches the new UID structure uid://X1/X2/X3#kdgflf
+UID_EXPRESSION = re.compile(r"^[uU][iI][dD]:/(/[xX][0-9,a-f,A-F]+){3}(#\w{1,}){0,}$")
+
+# Python 2/3 workaround
+message_from_file = email.message_from_file
+if sys.version_info[0] > 2:
+    message_from_file = email.message_from_binary_file
 
 logger = logging.getLogger(__name__)
 
-_PLUGIN_ID = __name__
 
-def specificTreatment(fo):
+def specific_treatment(file_path):
     """
-    Method contains the specific treatment of the file passed from NG/AMS.
-
-    fo:         File object
-
-    Returns:    (file_id, finalFileName, type);
-                The finalFileName is a string containing the name of the final
-                file without extension. type is the mime-type from the header.
+    Method contains the specific treatment of the file passed from NG/AMS
+    :param file_path: File path
+    :return: (file_id, final_filename, file_type); The final_filename is a string containing the name of the final
+             file without extension. file_type is the mime-type from the header.
     """
-    import rfc822, cgi, re
-    _EXT = '.msg'
-
-    filename = fo.name
-
-#    uidTempl = re.compile("[xX][0-9,a-f]{3,}/[xX][0-9,a-f]{1,}$")
-# This matches the old UID of type    X0123456789abcdef/X01234567
-
-    uidTempl = re.compile("^[uU][iI][dD]:/(/[xX][0-9,a-f,A-F]+){3}(#\w{1,}){0,}$")
-# This matches the new UID structure uid://X1/X2/X3#kdgflf
-
-
+    filename = os.path.basename(file_path)
     try:
-        message = rfc822.Message(fo)
-        type, tparams = cgi.parse_header(message["Content-Type"])
+        with open(file_path, "rb") as fo:
+            mime_message = message_from_file(fo)
     except Exception as e:
-        err = "Parsing of mime message failed: " + str(e)
-        errMsg = genLog("NGAMS_ER_DAPI_BAD_FILE", [os.path.basename(filename),
-                                                   _PLUGIN_ID, err])
-        raise Exception(errMsg)
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "Failed to open file: " + str(e)]))
+
+    if mime_message is None:
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE",
+                               [filename, PLUGIN_ID, "Failed to parse mime message"]))
+
+    file_type = mime_message.get_content_type()
+    alma_uid = mime_message["alma-uid"]
+    if alma_uid is None:
+        alma_uid = mime_message["Content-Location"]
+    if alma_uid is None:
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE",
+                               [filename, PLUGIN_ID,
+                                "Mandatory 'alma-uid' and/or 'Content-Location' parameter not found in mime header!"]))
+
+    if UID_EXPRESSION.match(alma_uid) is None:
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE",
+                               [filename, PLUGIN_ID, "Invalid alma-uid found in Content-Location: " + alma_uid]))
+
+    # Now, build final filename. We do that by looking for the UID in the message mime-header.
+    # The final filename is built as follows: <ALMA-UID>.<EXT> where ALMA-UID has the slash character in the UID
+    # replaced by colons.
     try:
-       almaUid, aparams = cgi.parse_header(message["alma-uid"])
-    except:
-
-        err = "Mandatory alma-uid parameter not found in mime header!"
-        errMsg = genLog("NGAMS_ER_DAPI_BAD_FILE", [os.path.basename(filename),
-                                               _PLUGIN_ID, err])
-        raise Exception(errMsg)
-
-    if not uidTempl.match(almaUid):
-        err = "Invalid alma-uid found: " + almaUid
-        errMsg = genLog("NGAMS_ER_DAPI_BAD_FILE", [os.path.basename(filename),
-                                               _PLUGIN_ID, err])
-        raise Exception(errMsg)
-
-# Now, build final filename. We do that by looking for the UID in
-# the message mime-header.
-
-# The final filename is built as follows: <almaUidR>.<ext>
-# where almaUidR has the slash character in the UID replaced by colons.
-    try:
-        # get rid of the 'uid://' and of anything following a '#' sign
-        almaUid = almaUid.split('//',2)[1].split('#')[0]
-        almaUid = almaUid.replace('x','X')
-
-        fileId = almaUid
-        finalFileName = almaUid.replace('/',':')
-# Have no idea why, but the extension is added somewhere else...
-#        if os.path.splitext(finalFileName)[-1] != _EXT:
-#            finalFileName += _EXT
-
+        # Get rid of the 'uid://' and of anything following a '#' sign
+        alma_uid = alma_uid.split("//", 2)[1].split("#")[0]
+        alma_uid = alma_uid.replace("x", "X")
+        file_id = alma_uid
+        final_filename = alma_uid.replace("/", ":")
     except Exception as e:
-        err = "Problem constructing final file name: " + str(e)
-        errMsg = genLog("NGAMS_ER_DAPI_BAD_FILE", [os.path.basename(filename),
-                                               _PLUGIN_ID, err])
-        raise Exception(errMsg)
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE",
+                               [filename, PLUGIN_ID, "Problem constructing final file name: " + str(e)]))
+
+    return file_id, final_filename, file_type
 
 
-    return (fileId, finalFileName, type)
-
-
-def ngamsAlmaMultipart(srvObj,
-                     reqPropsObj):
+def ngamsAlmaMultipart(ngams_server, request_properties):
     """
-    Data Archiving Plug-In to handle archiving of ALMA multipart related
-    message files containing ALMA UIDs.
-
-    srvObj:       Reference to NG/AMS Server Object (ngamsServer).
-
-    reqPropsObj:  NG/AMS request properties object (ngamsReqProps).
-
-    Returns:      Standard NG/AMS Data Archiving Plug-In Status
-                  as generated by: ngamsPlugInApi.genDapiSuccessStat()
-                  (ngamsDapiStatus).
+    Data Archiving Plug-In to handle archiving of ALMA multipart related message files containing ALMA UIDs
+    :param ngams_server: Reference to NG/AMS Server Object (ngamsServer)
+    :param request_properties: NG/AMS request properties object (ngamsReqProps)
+    :return: Standard NG/AMS Data Archiving Plug-In Status as generated by: ngamsPlugInApi.genDapiSuccessStat()
+             (ngamsDapiStatus)
     """
-
-
-
     # For now the exception handling is pretty basic:
-    # If something goes wrong during the handling it is tried to
-    # move the temporary file to the Bad Files Area of the disk.
-    logger.info("Plug-In handling data for file: " +
-         os.path.basename(reqPropsObj.getFileUri()))
-    diskInfo = reqPropsObj.getTargDiskInfo()
-    stagingFilename = reqPropsObj.getStagingFilename()
-    ext = os.path.splitext(stagingFilename)[1][1:]
+    # If something goes wrong during the handling it is tried to move the temporary file to the bad-files directory
+    logger.info("ALMA multipart plug-in handling data for file: %s", os.path.basename(reqPropsObj.getFileUri()))
 
-    fo = open(stagingFilename, "r")
-    (fileId, finalName, format) = specificTreatment(fo)
+    disk_info = request_properties.getTargDiskInfo()
+    staging_filename = request_properties.getStagingFilename()
 
-    fo.close()
+    file_id, final_filename, file_format = specific_treatment(staging_filename)
+
+    logger.debug("SDM multipart plug-in processing request for file with URI %s, file_format=%s, file_id=%s, file_version=%s," 
+                 " final_name=%s", request_properties.getFileUri(), file_format, file_id, file_version, final_filename)
+
     try:
-        # Compress the file.
-        uncomprSize = ngamsPlugInApi.getFileSize(stagingFilename)
+        # Compression parameters
+        uncompressed_size = ngamsPlugInApi.getFileSize(staging_filename)
         compression = ""
-#        info(2,"Compressing file using: %s ..." % compression)
-#        exitCode, stdOut = ngamsPlugInApi.execCmd("%s %s" %\
-#                                                  (compression,
-#                                                   stagingFilename))
-#        if (exitCode != 0):
-#            errMsg = _PLUGIN_ID+": Problems during archiving! " +\
-#                     "Compressing the file failed"
-#            raise Exception, errMsg
-#        stagingFilename = stagingFilename + ".Z"
-        # Remember to update the Temporary Filename in the Request
-        # Properties Object.
-        reqPropsObj.setStagingFilename(stagingFilename)
-#        info(2,"File compressed")
 
-        # ToDo: Handling of non-existing fileId
-#        if (fileId == -1):
-#            fileId = ngamsPlugInApi.genNgasId(srvObj.getCfg())
-        date = toiso8601(local=True, fmt=FMT_DATE_ONLY)
-        fileVersion, relPath, relFilename,\
-                     complFilename, fileExists =\
-                     ngamsPlugInApi.genFileInfo(srvObj.getDb(),
-                                                srvObj.getCfg(),
-                                                reqPropsObj, diskInfo,
-                                                stagingFilename, fileId,
-                                                finalName, [date])
+        # Remember to update the temporary file name in the request properties object
+        request_properties.setStagingFilename(staging_filename)
 
-        # Generate status.
-        logger.debug("Generating status ...")
-        if not format:
-            format = ngamsPlugInApi.determineMimeType(srvObj.getCfg(),
-                                                  stagingFilename)
-        fileSize = ngamsPlugInApi.getFileSize(stagingFilename)
-        return ngamsPlugInApi.genDapiSuccessStat(diskInfo.getDiskId(),
-                                                 relFilename,
-                                                 fileId, fileVersion, format,
-                                                 fileSize, uncomprSize,
-                                                 compression, relPath,
-                                                 diskInfo.getSlotId(),
-                                                 fileExists, complFilename)
+        today = ngamsCore.toiso8601(fmt=ngamsCore.FMT_DATE_ONLY)
+        file_version, relative_path, relative_filename, complete_filename, file_exists = \
+            ngamsPlugInApi.genFileInfo(ngams_server.getDb(), ngams_server.getCfg(), request_properties, disk_info,
+                                       staging_filename, file_id, final_filename, [today])
+
+        # Make sure the format is defined
+        if not file_format:
+            file_format = ngamsPlugInApi.determineMimeType(ngams_server.getCfg(), staging_filename)
+
+        file_size = ngamsPlugInApi.getFileSize(staging_filename)
+
+        return ngamsPlugInApi.genDapiSuccessStat(disk_info.getDiskId(), relative_filename, file_id, file_version,
+                                                 file_format, file_size, uncompressed_size, compression, relative_path,
+                                                 disk_info.getSlotId(), file_exists, complete_filename)
     except Exception as e:
-        errMsg = genLog("NGAMS_ER_DAPI_BAD_FILE", [os.path.basename(stagingFilename),
-                                                   _PLUGIN_ID, str(e)])
-        raise Exception(errMsg)
-
-if __name__ == "__main__":
-    import sys
-    if len(sys.argv) < 2:
-        print("Usage: ngamsAlmaMultipart.py <test_file>")
-        sys.exit()
-    try:
-        fo = open(sys.argv[1],'r')
-        (file_id,fileName, type) = specificTreatment(fo)
-        print(file_id, fileName, type)
-    except:
-        raise
-
-
-#
-# ___oOo___
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE",
+                               [staging_filename, PLUGIN_ID, "Problem processing file in staging area: " + str(e)]))

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_HTTPFETCH.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_HTTPFETCH.py
@@ -19,7 +19,7 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
-#******************************************************************************
+# *****************************************************************************
 #
 # "@(#) $Id: ngamsCmd_HTTPFETCH.py,v 1.1 2012/11/22 21:48:22 amanning Exp $"
 #
@@ -30,19 +30,16 @@
 """
 NGAS Command Plug-In, implementing an Archive Command specific for Mirroring
 
-This works in a similar way as the 'standard' ARCHIVE Command, but has been
-simplified in a few ways:
+This works in a similar way as the 'standard' ARCHIVE Command, but has been simplified in a few ways:
 
-  - No replication to a Replication Volume is carried out.
-  - Target disks are selected randomly, disregarding the Streams/Storage Set
-    mappings in the configuration. This means that 'volume load balancing' is
-    provided.
-  - Archive Proxy Mode is not supported.
-  - No probing for storage availability is supported.
-  - In general, less SQL queries are performed and the algorithm is more
-    light-weight.
-  - crc is computed from the incoming stream
-  - ngas_files data is 'cloned' from the source file
+* No replication to a Replication Volume is carried out.
+* Target disks are selected randomly, disregarding the Streams/Storage Set mappings in the configuration. This means
+that 'volume load balancing' is provided.
+* Archive Proxy Mode is not supported.
+* No probing for storage availability is supported.
+* In general, less SQL queries are performed and the algorithm is more light-weight.
+* crc is computed from the incoming stream
+* ngas_files data is 'cloned' from the source file
 """
 
 import contextlib
@@ -59,41 +56,23 @@ from . import ngamsFailedDownloadException
 logger = logging.getLogger(__name__)
 
 
-def saveToFile(srvObj,
-               ngamsCfgObj,
-               reqPropsObj,
-               trgFilename,
-               blockSize,
-               startByte):
+def save_to_file(ngams_server, request_properties, target_filename, block_size, start_byte):
     """
-    Save the data available on an HTTP channel into the given file.
-
-    ngamsCfgObj:     NG/AMS Configuration object (ngamsConfig).
-
-    reqPropsObj:     NG/AMS Request Properties object (ngamsReqProps).
-
-    trgFilename:     Target name for file where data will be
-                     written (string).
-
-    blockSize:       Block size (bytes) to apply when reading the data
-                     from the HTTP channel (integer).
-
-    mutexDiskAccess: Require mutual exclusion for disk access (integer).
-
-    diskInfoObj:     Disk info object. Only needed if mutual exclusion
-                     is required for disk access (ngamsDiskInfo).
-
-    Returns:         Tuple. Element 0: Time in took to write
-                     file (s) (tuple).
+    Save the data available on an HTTP channel into the given file
+    :param ngams_server: Reference to NG/AMS server class object (ngamsServer)
+    :param request_properties: NG/AMS Request Properties object (ngamsReqProps)
+    :param target_filename: Target name for file where data will be written (string)
+    :param block_size: Block size (bytes) to apply when reading the data from the HTTP channel (integer)
+    :param start_byte: Start byte offset
+    :return: Tuple. Element 0: Time in took to write file (s) (tuple)
     """
-
-    disk_id = reqPropsObj.fileinfo['diskId']
-    source_host = reqPropsObj.fileinfo['sourceHost']
-    host_id = reqPropsObj.fileinfo['hostId']
-    file_version = reqPropsObj.fileinfo['fileVersion']
-    file_id = reqPropsObj.fileinfo['fileId']
-    checksum = reqPropsObj.checksum
-    crc_variant = reqPropsObj.checksum_plugin
+    disk_id = request_properties.fileinfo['diskId']
+    source_host = request_properties.fileinfo['sourceHost']
+    host_id = request_properties.fileinfo['hostId']
+    file_version = request_properties.fileinfo['fileVersion']
+    file_id = request_properties.fileinfo['fileId']
+    checksum = request_properties.checksum
+    crc_variant = request_properties.checksum_plugin
 
     host, port = source_host.split(":")
     pars = {
@@ -103,99 +82,97 @@ def saveToFile(srvObj,
         'file_version': file_version,
         'file_id': file_id
     }
-    hdrs = {'Range': "bytes={:d}-".format(startByte)}
+    hdrs = {'Range': "bytes={:d}-".format(start_byte)}
 
     rx_timeout = 30 * 60
-    if srvObj.getCfg().getVal("Mirroring[1].rx_timeout"):
-        rx_timeout = int(srvObj.getCfg().getVal("Mirroring[1].rx_timeout"))
+    if ngams_server.getCfg().getVal("Mirroring[1].rx_timeout"):
+        rx_timeout = int(ngams_server.getCfg().getVal("Mirroring[1].rx_timeout"))
     response = ngamsHttpUtils.httpGet(host, int(port), 'RETRIEVE', pars=pars, hdrs=hdrs, timeout=rx_timeout)
 
-    # can we resume a previous download?
-    downloadResumeSupported = 'bytes' in response.getheader("Accept-Ranges", '')
+    # Can we resume a previous download?
+    download_resume_supported = 'bytes' in response.getheader("Accept-Ranges", '')
 
-    logger.debug("Creating path: %s", trgFilename)
-    checkCreatePath(os.path.dirname(trgFilename))
+    logger.debug("Creating path: %s", target_filename)
+    checkCreatePath(os.path.dirname(target_filename))
 
     logger.info('Fetching file ID %s, checksum %s, checksum variant %s', file_id, checksum, crc_variant)
     crc_info = ngamsFileUtils.get_checksum_info(crc_variant)
-    if startByte != 0:
+    if start_byte != 0:
         logger.info("resume requested")
-    if startByte != 0 and downloadResumeSupported:
+    if start_byte != 0 and download_resume_supported:
         logger.info("Resume requested and mirroring source supports resume. Appending data to previously started staging file")
-        crc = ngamsFileUtils.get_checksum(65536, trgFilename, crc_variant)
-        reqPropsObj.setBytesReceived(startByte)
-        fdOut = open(trgFilename, "a")
+        crc = ngamsFileUtils.get_checksum(65536, target_filename, crc_variant)
+        request_properties.setBytesReceived(start_byte)
+        fd_out = open(target_filename, "a")
     else:
-        if startByte > 0:
+        if start_byte > 0:
             logger.info("Resume of download requested but server does not support it. Starting from byte 0 again.")
-        fdOut = open(trgFilename, "w")
+        fd_out = open(target_filename, "w")
         crc = crc_info.init
 
-    start = time.time()
+    fetch_start_time = time.time()
 
-    # Distinguish between Archive Pull and Push Request. By Archive
-    # Pull we may simply read the file descriptor until it returns "".
+    # Distinguish between Archive Pull and Push Request. By Archive pull we may simply read the file descriptor until
+    # it returns "".
     logger.info("It is an HTTP Archive Pull Request: trying to get Content-length")
     hdrs = {h[0]: h[1] for h in response.getheaders()}
     if 'content-length' in hdrs:
-        remSize = int(hdrs['content-length'])
+        remaining_size = int(hdrs['content-length'])
     else:
         logger.warning("No Content-Length header found, defaulting to 1e11")
-        remSize = int(1e11)
+        remaining_size = int(1e11)
 
-    # Receive the data.
-    buf = "-"
-    rdSize = blockSize
+    # Receive the data
+    read_size = block_size
 
-    crctime = 0
-    rtime = 0
-    wtime = 0
-    readin = 0
+    crc_duration = 0
+    read_duration = 0
+    write_duration = 0
+    read_total_bytes = 0
 
-    crc_m = crc_info.method
-    with contextlib.closing(response), contextlib.closing(fdOut):
-        while remSize > 0:
-            if remSize < rdSize:
-                rdSize = remSize
+    crc_method = crc_info.method
+    with contextlib.closing(response), contextlib.closing(fd_out):
+        while remaining_size > 0:
+            if remaining_size < read_size:
+                read_size = remaining_size
 
-            # Read
-            rstart = time.time()
-            buf = response.read(rdSize)
-            rtime += time.time() - rstart
-            sizeRead = len(buf)
-            readin += sizeRead
+            # Read the remote file
+            read_start_time = time.time()
+            data_buffer = response.read(read_size)
+            read_duration += time.time() - read_start_time
+            size_read = len(data_buffer)
+            read_total_bytes += size_read
 
-            if sizeRead == 0:
+            if size_read == 0:
                 raise ngamsFailedDownloadException.FailedDownloadException("server is unreachable")
 
             # CRC
-            crcstart = time.time()
-            crc = crc_m(buf, crc)
-            crctime += time.time() - crcstart
+            crc_start_time = time.time()
+            crc = crc_method(data_buffer, crc)
+            crc_duration += time.time() - crc_start_time
 
-            remSize -= sizeRead
-            reqPropsObj.setBytesReceived(reqPropsObj.getBytesReceived() + sizeRead)
+            remaining_size -= size_read
+            request_properties.setBytesReceived(request_properties.getBytesReceived() + size_read)
 
-            # Write
-            wstart = time.time()
-            fdOut.write(buf)
-            wtime += time.time() - wstart
+            # Write the file onto disk
+            write_start_time = time.time()
+            fd_out.write(data_buffer)
+            write_duration += time.time() - write_start_time
 
     crc = crc_info.final(crc)
 
-    total_time = time.time() - start
+    fetch_duration = time.time() - fetch_start_time
     # Avoid divide by zeros later on, let's say it took us 1 [us] to do this
-    if total_time == 0.0:
-        total_time = 0.000001
+    if fetch_duration == 0.0:
+        fetch_duration = 0.000001
 
-    msg = "Saved data in file: %s. Bytes received: %d. Time: %.3f s. " +\
-          "Rate: %.2f Bytes/s"
-    logger.info(msg, trgFilename, int(reqPropsObj.getBytesReceived()), total_time,
-                (float(reqPropsObj.getBytesReceived()) / total_time))
+    msg = "Saved data in file: %s. Bytes received: %d. Time: %.3f s. Rate: %.2f Bytes/s"
+    logger.info(msg, target_filename, int(request_properties.getBytesReceived()), fetch_duration,
+                (float(request_properties.getBytesReceived()) / fetch_duration))
 
     # Raise exception if bytes received were less than expected
-    if remSize != 0:
-        msg = "No all expected data arrived, {:d} bytes left to read".format(remSize)
+    if remaining_size != 0:
+        msg = "No all expected data arrived, {:d} bytes left to read".format(remaining_size)
         raise ngamsFailedDownloadException.FailedDownloadException(msg)
 
     # Now check the freshly calculated CRC value against the stored CRC value
@@ -204,4 +181,5 @@ def saveToFile(srvObj,
         msg = "checksum mismatch: source={:s}, received={:d}".format(checksum, crc)
         raise ngamsFailedDownloadException.FailedDownloadException(msg)
 
-    return archiving_results(readin, rtime, wtime, crctime, total_time, crc_variant, crc)
+    return archiving_results(read_total_bytes, read_duration, write_duration, crc_duration, fetch_duration,
+                             crc_variant, crc)

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRRARCHIVE.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRRARCHIVE.py
@@ -19,7 +19,7 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
-#******************************************************************************
+# *****************************************************************************
 #
 # "@(#) $Id: ngamsCmd_MIRRARCHIVE.py,v 1.6 2010/06/17 14:23:45 awicenec Exp $"
 #
@@ -30,231 +30,193 @@
 """
 NGAS Command Plug-In, implementing an Archive Command specific for Mirroring
 
-This works in a similar way as the 'standard' ARCHIVE Command, but has been
-simplified in a few ways:
+This works in a similar way as the 'standard' ARCHIVE Command, but has been simplified in a few ways:
 
-  - No replication to a Replication Volume is carried out.
-  - Target disks are selected randomly, disregarding the Streams/Storage Set
-    mappings in the configuration. This means that 'volume load balancing' is
-    provided.
-  - Archive Proxy Mode is not supported.
-  - No probing for storage availability is supported.
-  - In general, less SQL queries are performed and the algorithm is more
-    light-weight.
-  - crc is computed from the incoming stream
-  - ngas_files data is 'cloned' from the source file
+* No replication to a Replication Volume is carried out.
+* Target disks are selected randomly, disregarding the Streams/Storage Set mappings in the configuration. This means
+that 'volume load balancing' is provided.
+* Archive Proxy Mode is not supported.
+* No probing for storage availability is supported.
+* In general, less SQL queries are performed and the algorithm is more light-weight.
+* crc is computed from the incoming stream
+* ngas_files data is 'cloned' from the source file
 """
 
-import binascii
 import logging
 import os
 import time
 
 from ngamsLib import ngamsDiskInfo, ngamsDbCore
-from ngamsLib.ngamsCore import genLog, NGAMS_ONLINE_STATE, \
-    mvFile, getFileCreationTime, NGAMS_FILE_STATUS_OK
-from . import ngamsFailedDownloadException
-from . import ngamsDAPIMirroring
-from . import ngamsCmd_RSYNCFETCH
+from ngamsLib.ngamsCore import genLog, getFileCreationTime, mvFile, NGAMS_FILE_STATUS_OK, NGAMS_ONLINE_STATE
 from . import ngamsCmd_HTTPFETCH
-
+from . import ngamsCmd_RSYNCFETCH
+from . import ngamsDAPIMirroring
+from . import ngamsFailedDownloadException
 
 logger = logging.getLogger(__name__)
 
-def getTargetVolume(srvObj):
+
+def get_target_volume(ngams_server):
     """
-    Get a random target volume with availability.
-
-    srvObj:         Reference to NG/AMS server class object (ngamsServer).
-
-    Returns:        Target volume object or None (ngamsDiskInfo | None).
+    Get a random target volume with availability
+    :param ngams_server: Reference to NG/AMS server class object (ngamsServer)
+    :return: Target volume object or None (ngamsDiskInfo | None)
     """
-
-    sqlQuery = "SELECT %s FROM ngas_disks nd WHERE completed=0 AND " + \
-               "host_id={0} order by available_mb desc" % ngamsDbCore.getNgasDisksCols()
-    res = srvObj.getDb().query2(sqlQuery, args=(srvObj.getHostId(),))
-    if not res:
+    sql = "select %s from ngas_disks nd " \
+          "where completed=0 AND host_id={0} order by available_mb desc" % ngamsDbCore.getNgasDisksCols()
+    result = ngams_server.getDb().query2(sql, args=(ngams_server.getHostId(),))
+    if not result:
         return None
     else:
-        return ngamsDiskInfo.ngamsDiskInfo().unpackSqlResult(res[0])
+        return ngamsDiskInfo.ngamsDiskInfo().unpackSqlResult(result[0])
 
-def updateDiskInfo(srvObj,
-                   resDapi,
-                   availSpace):
+
+def update_disk_info(ngams_server, result_dapi, available_space):
     """
-    Update the row for the volume hosting the new file.
-
-    srvObj:     Reference to NG/AMS server class object (ngamsServer).
-
-    resDapi:    Result returned from the DAPI (ngamsDapiStatus).
-
-    availSpace: Remaining space in disk (in mb)
-
-    Returns:   Void.
+    Update the row for the volume hosting the new file
+    :param ngams_server: Reference to NG/AMS server class object (ngamsServer)
+    :param result_dapi: Result returned from the DAPI (ngamsDapiStatus)
+    :param available_space: Remaining space in disk (in MB)
     """
-    sqlQuery = "UPDATE ngas_disks SET " +\
-               "number_of_files=(number_of_files + 1), " +\
-               "available_mb = {0}, " +\
-               "bytes_stored = (bytes_stored + {1}) WHERE " +\
-               "disk_id = {2}"
-    srvObj.getDb().query2(sqlQuery, args=(availSpace, resDapi.getFileSize(), resDapi.getDiskId()))
+    sql = "update ngas_disks " \
+          "set number_of_files=(number_of_files + 1), available_mb = {0}, bytes_stored = (bytes_stored + {1}) " \
+          "where disk_id = {2}"
+    ngams_server.getDb().query2(sql, args=(available_space, result_dapi.getFileSize(), result_dapi.getDiskId()))
 
 
-def saveInStagingFile(srvObj,
-                      ngamsCfgObj,
-                      reqPropsObj,
-                      stagingFilename,
-                      startByte):
+def save_in_staging_file(ngams_server, ngams_config, request_properties, staging_filename, start_byte):
     """
-    Save the data ready on the HTTP channel, into the given Staging
-    Area file.
-
-    ngamsCfgObj:     NG/AMS Configuration (ngamsConfig).
-
-    reqPropsObj:     NG/AMS Request Properties object (ngamsReqProps).
-
-    stagingFilename: Staging Area Filename as generated by
-                     ngamsHighLevelLib.genStagingFilename() (string).
-
-    diskInfoObj:     Disk info object. Only needed if mutual exclusion
-                     is required for disk access (ngamsDiskInfo).
-
-    Returns:         Void.
+    Save the data ready on the HTTP channel, into the given staging area file
+    :param ngams_server: Reference to NG/AMS server class object (ngamsServer)
+    :param ngams_config: NG/AMS Configuration (ngamsConfig)
+    :param request_properties: NG/AMS Request Properties object (ngamsReqProps)
+    :param staging_filename: Staging Area Filename as generated by ngamsHighLevelLib.genStagingFilename() (string)
+    :param start_byte: Start byte offset
+    :return: File save to archive status information (tuple)
     """
-    blockSize = ngamsCfgObj.getBlockSize()
-    fetchMethod = 'HTTP'
-    if ngamsCfgObj.getVal("Mirroring[1].fetch_method"):
-        fetchMethod = ngamsCfgObj.getVal("Mirroring[1].fetch_method")
-    if fetchMethod == 'RSYNC':
-        info = ngamsCmd_RSYNCFETCH.saveToFile(srvObj, ngamsCfgObj, reqPropsObj, stagingFilename,
-                                  blockSize, startByte)
+    block_size = ngams_config.getBlockSize()
+    fetch_method = 'HTTP'
+    if ngams_config.getVal("Mirroring[1].fetch_method"):
+        fetch_method = ngams_config.getVal("Mirroring[1].fetch_method")
+    if fetch_method == 'RSYNC':
+        info = ngamsCmd_RSYNCFETCH.save_to_file(ngams_server, request_properties, staging_filename)
     else:
-        info = ngamsCmd_HTTPFETCH.saveToFile(srvObj, ngamsCfgObj, reqPropsObj, stagingFilename,
-                                  blockSize, startByte)
+        info = ngamsCmd_HTTPFETCH.save_to_file(ngams_server, request_properties, staging_filename,
+                                               block_size, start_byte)
     return info
 
-def calculateCrc(filename, blockSize):
-    crc = 0
-    try:
-        fdin = open(filename, "r")
-        buff = "-"
-        while len(buffer) > 0:
-            buff = fdin.read(blockSize)
-            crc = binascii.crc32(buff, crc)
-    finally:
-        fdin.close()
-    return crc
 
-def handleCmd(srvObj, reqPropsObj):
-    if srvObj.getState() == NGAMS_ONLINE_STATE:
-        __handleCmd(srvObj, reqPropsObj)
+def handleCmd(ngams_server, request_properties, http_reference=None):
+    """
+    Plug-in module handle command function part of plug-in API
+    :param ngams_server: Reference to NG/AMS server class object (ngamsServer)
+    :param request_properties: NG/AMS Request Properties object (ngamsReqProps)
+    :param http_reference: HTTP reference
+    """
+    if ngams_server.getState() == NGAMS_ONLINE_STATE:
+        __handle_command(ngams_server, request_properties)
     else:
         raise ngamsFailedDownloadException.AbortedException("Server is OFFLINE")
 
-def __handleCmd(srvObj, reqPropsObj):
+
+def __handle_command(ngams_server, request_properties):
     """
-    Handle the Mirroring Archive (MIRRARCHIVE) Command.
-
-    srvObj:         Reference to NG/AMS server class object (ngamsServer).setState
-
-
-    reqPropsObj:    Request Property object to keep track of actions done
-                    during the request handling (ngamsReqProps).
-
-    Returns:        Void.
+    Handle the mirroring archive command (MIRRARCHIVE)
+    :param ngams_server: Reference to NG/AMS server class object (ngamsServer).setState
+    :param request_properties: Request Property object to keep track of actions done during the request handling
+    (ngamsReqProps).
     """
     # Is this NG/AMS permitted to handle Archive Requests?
     logger.debug("Checking if this NG/AMS permitted to handle Archive Requests?")
-    if (not srvObj.getCfg().getAllowArchiveReq()):
-        errMsg = genLog("NGAMS_ER_ILL_REQ", ["Archive"])
-        raise Exception(errMsg)
+    if not ngams_server.getCfg().getAllowArchiveReq():
+        error_message = genLog("NGAMS_ER_ILL_REQ", ["Archive"])
+        raise Exception(error_message)
 
-    # Generate staging filename.
-    stgFilename = reqPropsObj.getStagingFilename()
-    logger.info("staging filename is: %s", stgFilename)
-    startByte = 0
-    if (os.path.exists(stgFilename) == 0):
-        logger.debug('this is a new staging file')
+    # Generate staging filename
+    staging_filename = request_properties.getStagingFilename()
+    logger.info("Staging filename is: %s", staging_filename)
+    start_byte = 0
+    if os.path.exists(staging_filename) == 0:
+        logger.debug('Staging file %s is a new file', staging_filename)
     else:
-        startByte = os.path.getsize(stgFilename)
-        logger.debug('staging file already exists, requesting resumption of download from byte %d', startByte)
+        start_byte = os.path.getsize(staging_filename)
+        logger.debug('Staging file %s already exists, requesting resumption of download from byte %d',
+                     staging_filename, start_byte)
 
-    # Set reference in request handle object to the read socket.
+    # Set reference in request handle object to the read socket
     try:
         # Retrieve file_id and file_version from request proposal
-        file_id = reqPropsObj.fileinfo['fileId']
-        file_version = reqPropsObj.fileinfo['fileVersion']
+        file_id = request_properties.fileinfo['fileId']
+        file_version = request_properties.fileinfo['fileVersion']
         logger.debug("Got file_id=%s and file_version=%s", file_id, file_version)
 
-        # Retrieve file contents (from URL, archive pull, or by storing the body
-        # of the HTTP request, archive push).
-        logger.info("Saving in staging file: %s", stgFilename)
-        stagingInfo = saveInStagingFile(srvObj, srvObj.getCfg(), reqPropsObj,
-                                        stgFilename, startByte)
-        reqPropsObj.incIoTime(stagingInfo.rtime)
-        reqPropsObj.incIoTime(stagingInfo.wtime)
-        ingest_rate = int(reqPropsObj.getSize() // stagingInfo.totaltime)
+        # Retrieve file contents (from URL, archive pull, or by storing the body of the HTTP request, archive push)
+        logger.info("Saving contents in staging file: %s", staging_filename)
+        staging_info = save_in_staging_file(ngams_server, ngams_server.getCfg(), request_properties,
+                                            staging_filename, start_byte)
+        request_properties.incIoTime(staging_info.rtime)
+        request_properties.incIoTime(staging_info.wtime)
+        ingest_rate = int(request_properties.getSize() // staging_info.totaltime)
     except (ngamsFailedDownloadException.FailedDownloadException, ngamsFailedDownloadException.PostponeException):
         raise
     except Exception as e:
         if getattr(e, 'errno', 0) == 28:
-            # we can't resume, otherwise the same host will be used next time
-            logger.warning("Ran out of disk space during the download to %s. Marking as FAILURE", stgFilename)
+            # We cannot resume, otherwise the same host will be used next time
+            logger.warning("Ran out of disk space during the download to %s. Marking as FAILURE", staging_filename)
             # TODO: automatically mark the volume as completed
-            # TODO: try something more sophisticated with the file - other
-            #       volumes on the same host? Or at least ARCHIVE in another
-            #       host avoiding the download of WAN again. This is
-            #       particularly important if we just downloaded most of a
-            #       300GB file
+            # TODO: try something more sophisticated with the file - other volumes on the same host?
+            #  Or at least ARCHIVE in another host avoiding the download of WAN again. This is particularly
+            #  important if we just downloaded most of a 300GB file
             raise ngamsFailedDownloadException.FailedDownloadException(e)
-        elif reqPropsObj.getBytesReceived() >= 0:
-            logger.warning("the fetch has already downloaded data. marking as TORESUME")
+        elif request_properties.getBytesReceived() >= 0:
+            logger.warning("A fetch has already downloaded data. Marking as TORESUME")
             raise ngamsFailedDownloadException.PostponeException(e)
         else:
-            logger.warning(3, "no data has been downloaded yet. Marking as FAILURE")
+            logger.warning("No data has been downloaded yet. Marking as FAILURE")
             raise ngamsFailedDownloadException.FailedDownloadException(e)
 
     # Invoke DAPI
-    logger.info("Invoking DAPI")
-    resDapi = ngamsDAPIMirroring.ngamsGeneric(srvObj, reqPropsObj)
+    logger.info("Invoking DAPI for mirroring")
+    result_dapi = ngamsDAPIMirroring.ngamsGeneric(ngams_server, request_properties)
 
-    # Move file to final destination.
-    logger.info("Moving file to final destination: %s", resDapi.getCompleteFilename())
-    mtime = mvFile(reqPropsObj.getStagingFilename(), resDapi.getCompleteFilename())
-    reqPropsObj.incIoTime(mtime)
+    # Move file to final destination
+    logger.info("Moving file to final destination: %s", result_dapi.getCompleteFilename())
+    mtime = mvFile(request_properties.getStagingFilename(), result_dapi.getCompleteFilename())
+    request_properties.incIoTime(mtime)
 
-    # Check/generate remaining file info + update in DB.
-    logger.info("Creating db entry")
-    creDate = srvObj.getDb().convertTimeStamp(getFileCreationTime(resDapi.getCompleteFilename()))
-    sqlUpdate = "update ngas_disks set available_mb = available_mb - {0} / (1024 * 1024), bytes_stored = bytes_stored + {1} " +\
-                "where disk_id = {2}"
-    srvObj.getDb().query2(sqlUpdate, args=(resDapi.getFileSize(), resDapi.getFileSize(), resDapi.getDiskId()))
+    # Check/generate remaining file info and update in DB
+    logger.info("Creating DB entry")
+    creation_date = ngams_server.getDb().convertTimeStamp(getFileCreationTime(result_dapi.getCompleteFilename()))
+    sql = "update ngas_disks " \
+          "set available_mb = available_mb - {0} / (1024 * 1024), bytes_stored = bytes_stored + {1} " \
+          "where disk_id = {2}"
+    ngams_server.getDb().query2(sql, args=(result_dapi.getFileSize(), result_dapi.getFileSize(),
+                                           result_dapi.getDiskId()))
 
-    ts = srvObj.getDb().convertTimeStamp(time.time())
-    io_time = int(reqPropsObj.getIoTime() * 1000)
-    sqlQuery = "INSERT INTO ngas_files " +\
-               "(disk_id, file_name, file_id, " +\
-               "file_version, format, file_size, " +\
-               "uncompressed_file_size, compression, ingestion_date, " +\
-               "{:s}, ".format('file_ignore' if srvObj.getCfg().getDbUseFileIgnore() else 'ignore') +\
-               "checksum, checksum_plugin, file_status, " +\
-               "creation_date, io_time, ingestion_rate) " +\
-               "VALUES " +\
-               "({}, {}, {}, " +\
-               "{}, {}, {}, " +\
-               "{}, {},  {}, " +\
-               "0, " +\
-               "{}, {}, {}, " +\
-               "{}, {}, {})"
-    args = (str(resDapi.getDiskId()), str(resDapi.getRelFilename()), file_id,
-            file_version, str(resDapi.getFormat()), resDapi.getFileSize(),
-            resDapi.getUncomprSize(), str(resDapi.getCompression()), ts,
-            str(stagingInfo.crc), stagingInfo.crcname, NGAMS_FILE_STATUS_OK,
-            creDate, io_time, ingest_rate)
-    logger.info("Will try to insert the file information: %s / %r", sqlQuery, args)
-    srvObj.getDb().query2(sqlQuery, args=args)
+    timestamp = ngams_server.getDb().convertTimeStamp(time.time())
+    io_time = int(request_properties.getIoTime() * 1000)
+    sql = "insert into ngas_files " \
+          "(disk_id, file_name, file_id, " \
+          "file_version, format, file_size, " \
+          "uncompressed_file_size, compression, ingestion_date, " \
+          "{:s}, ".format('file_ignore' if ngams_server.getCfg().getDbUseFileIgnore() else 'ignore') +\
+          "checksum, checksum_plugin, file_status, " \
+          "creation_date, io_time, ingestion_rate) " \
+          "VALUES " \
+          "({}, {}, {}, " \
+          "{}, {}, {}, " \
+          "{}, {},  {}, " \
+          "0, " \
+          "{}, {}, {}, " \
+          "{}, {}, {})"
+    args = (str(result_dapi.getDiskId()), str(result_dapi.getRelFilename()), file_id,
+            file_version, str(result_dapi.getFormat()), result_dapi.getFileSize(),
+            result_dapi.getUncomprSize(), str(result_dapi.getCompression()), timestamp,
+            str(staging_info.crc), staging_info.crcname, NGAMS_FILE_STATUS_OK,
+            creation_date, io_time, ingest_rate)
+    logger.info("Will try to insert the file information: %s / %r", sql, args)
+    ngams_server.getDb().query2(sql, args=args)
 
     logger.info("Successfully handled Archive Pull Request for data file with URI: %s",
-            reqPropsObj.getSafeFileUri())
-
+                request_properties.getSafeFileUri())
     return

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRRARCHIVE.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRRARCHIVE.py
@@ -177,7 +177,7 @@ def __handle_command(ngams_server, request_properties):
 
     # Invoke DAPI
     logger.info("Invoking DAPI for mirroring")
-    result_dapi = ngamsDAPIMirroring.ngamsGeneric(ngams_server, request_properties)
+    result_dapi = ngamsDAPIMirroring.ngams_generic(ngams_server, request_properties)
 
     # Move file to final destination
     logger.info("Moving file to final destination: %s", result_dapi.getCompleteFilename())

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRREXEC.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRREXEC.py
@@ -284,7 +284,7 @@ def get_num_download_threads_in_use(current_iteration, target_node, ngams_server
 
 def revert_mirroring_bookkeeping_entries(current_iteration, target_node, ngams_server):
     sql = "delete from ngas_mirroring_bookkeeping " \
-          "where target_host = :targetNode and iteration = :iteration and status = 'READY'"
+          "where target_host = {0} and iteration = {1} and status = 'READY'"
     ngams_server.getDb().query2(sql, args=(target_node, current_iteration))
 
 

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRREXEC.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRREXEC.py
@@ -19,7 +19,7 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
-#******************************************************************************
+# *****************************************************************************
 #
 # "@(#) $Id: ngamsCmd_MIRREXEC.py,v 1.7 2010/06/22 18:55:03 awicenec Exp $"
 #
@@ -30,26 +30,28 @@
 """
 NGAS Command Plug-In, implementing a command to actually perform mirroring tasks
 
-NOTES:
-    By default it performs pending mirroring tasks assigned to the NGAS server
-    handling the command, but when mirror_cluster is specified (=1), default (=0),
-    all pending mirroring tasks assigned to the local cluster are processed.
+NOTES
+-----
+By default it performs pending mirroring tasks assigned to the NGAS server handling the command, but when
+mirror_cluster is specified (=1), default (=0), all pending mirroring tasks assigned to the local cluster are
+processed.
 
-PARAMETERS:
-    -mirror_cluster [optional]    (=0), process all pending mirroring tasks assigned to the NGAS server handling the command
-                    (=1), process all pending mirroring tasks assigned to the local cluster
-                          (centralizing the process from the NGAS server handling the command)
-                    (=2), process all pending mirroring tasks assigned to the local cluster
-                          (distributing the process to the active nodes in the local cluster)
-    -order                (=0), Start mirroring sequence order with small files
-                    (=1), Start mirroring sequence order with big files
+PARAMETERS
+----------
+* mirror_cluster [optional] (=0), process all pending mirroring tasks assigned to the NGAS server handling the command
+                            (=1), process all pending mirroring tasks assigned to the local cluster
+                                (centralizing the process from the NGAS server handling the command)
+                            (=2), process all pending mirroring tasks assigned to the local cluster
+                                (distributing the process to the active nodes in the local cluster)
+* order                     (=0), Start mirroring sequence order with small files
+                            (=1), Start mirroring sequence order with big files
 
-EXAMPLES:
-    - Carry out pending mirroring tasks for this NGAS server using 4 threads per source node
+EXAMPLES
+--------
+* Carry out pending mirroring tasks for this NGAS server using 4 threads per source node
     http://ngas05.hq.eso.org:7778/MIRREXEC?n_threads=4
-    - Carry out all pending mirroring tasks assigned to the local cluster using 2 threads per source node
+* Carry out all pending mirroring tasks assigned to the local cluster using 2 threads per source node
     http://ngas05.hq.eso.org:7778/MIRREXEC?mirror_cluster=1&n_threads=2
-
 """
 
 import contextlib
@@ -59,146 +61,117 @@ import os
 import time
 import threading
 
-from ngamsLib import ngamsLib, ngamsHttpUtils, ngamsReqProps, ngamsDiskInfo,\
-    ngamsDbCore
-from ngamsLib.ngamsCore import toiso8601, NGAMS_STAGING_DIR, genUniqueId,\
-    NGAMS_FAILURE, NGAMS_HTTP_SUCCESS, FMT_DATETIME_NOMSEC
+from ngamsLib import ngamsLib, ngamsHttpUtils, ngamsReqProps, ngamsDiskInfo, ngamsDbCore
+from ngamsLib.ngamsCore import genUniqueId, toiso8601,\
+    FMT_DATETIME_NOMSEC, NGAMS_FAILURE, NGAMS_HTTP_SUCCESS, NGAMS_STAGING_DIR
 from . import ngamsFailedDownloadException
 from . import ngamsCmd_MIRRARCHIVE
 
-
 logger = logging.getLogger(__name__)
 
-def handleCmd(srvObj,
-              reqPropsObj,
-              httpRef):
+
+def handleCmd(ngams_server, request_properties, http_reference=None):
     """
     Handle Command MIRRTABLE to populate bookkeeping table in target cluster
-
-    INPUT:
-        srvObj:         ngamsServer, Reference to NG/AMS server class object
-
-        reqPropsObj:    ngamsReqProps, Request Property object to keep track
-                        of actions done during the request handling
-
-       httpRef:        ngamsHttpRequestHandler, Reference to the HTTP request
-                        handler object
-
-    RETURNS:        Void.
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :param request_properties: ngamsReqProps, Request Property object to keep track of actions done during the
+    request handling
+    :param http_reference: HTTP reference
     """
-    # Get command parameters.
+    # Get command parameters
     mirror_cluster = 0
     n_threads = 2
     rx_timeout = None
-    if (reqPropsObj.hasHttpPar("mirror_cluster")):
-        mirror_cluster = int(reqPropsObj.getHttpPar("mirror_cluster"))
-    if (reqPropsObj.hasHttpPar("n_threads")):
-        n_threads = int(reqPropsObj.getHttpPar("n_threads"))
-    if (reqPropsObj.hasHttpPar("rx_timeout")):
-        rx_timeout = int(reqPropsObj.getHttpPar("rx_timeout"))
-    current_iteration = int(reqPropsObj.getHttpPar("iteration"))
+    if request_properties.hasHttpPar("mirror_cluster"):
+        mirror_cluster = int(request_properties.getHttpPar("mirror_cluster"))
+    if request_properties.hasHttpPar("n_threads"):
+        n_threads = int(request_properties.getHttpPar("n_threads"))
+    if request_properties.hasHttpPar("rx_timeout"):
+        rx_timeout = int(request_properties.getHttpPar("rx_timeout"))
+    current_iteration = int(request_properties.getHttpPar("iteration"))
 
     # Distributed cluster mirroring
-    if (mirror_cluster):
-        # Get cluster name
-        local_cluster_name = get_cluster_name(srvObj)
-        # Get active target nodes
-        active_target_nodes = get_active_target_nodes(local_cluster_name, current_iteration, srvObj)
+    if mirror_cluster:
+        local_cluster_name = get_cluster_name(ngams_server)
+        active_target_nodes = get_active_target_nodes(local_cluster_name, current_iteration, ngams_server)
         # Start mirroring
-        distributed_mirroring(active_target_nodes,n_threads, rx_timeout, current_iteration)
+        distributed_mirroring(active_target_nodes, n_threads, rx_timeout, current_iteration)
     else:
-        # Get full qualified name of this server
-        local_server_full_qualified_name = get_full_qualified_name(srvObj)
+        local_server_full_qualified_name = get_fully_qualified_name(ngams_server)
         # Format full qualified name as a list
         active_target_nodes = [local_server_full_qualified_name]
-        # Get active source nodes
-        active_source_nodes = get_active_source_nodes(srvObj,current_iteration, full_qualified_name=local_server_full_qualified_name)
+        active_source_nodes = get_active_source_nodes(ngams_server, current_iteration,
+                                                      fully_qualified_name=local_server_full_qualified_name)
         # Start mirroring process driven by this host
-        logger.info("Performing mirroring tasks from (%s) to (%s) using %s threads per source node and target node",
-                     str(active_source_nodes),str(active_target_nodes),str(n_threads))
+        logger.info("Performing mirroring tasks from (%s) to (%s) using %d threads per source node and target node",
+                    str(active_source_nodes), str(active_target_nodes), n_threads)
         try:
             # Set mirroring running flag to avoid data check thread and janitor thread
-            srvObj.mirroring_running = True
-            multithreading_mirroring(active_source_nodes, n_threads, rx_timeout, current_iteration, srvObj)
+            ngams_server.mirroring_running = True
+            multithreading_mirroring(active_source_nodes, n_threads, current_iteration, ngams_server)
         finally:
             # Set mirroring running flag to trigger data check thread and janitor thread
-            srvObj.mirroring_running = False
-
-    # Return Void
+            ngams_server.mirroring_running = False
     return
 
 
-def get_cluster_name(srvObj):
+def get_cluster_name(ngams_server):
     """
     Get cluster name corresponding to the processing NGAMS server
-
-    INPUT:
-        srvObj          ngamsServer, Reference to NG/AMS server class object
-
-    RETURNS:
-        cluster_name    string, name of the cluster corresponding to the input host_id
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :return: string, name of the cluster corresponding to the input host_id
     """
-    # Execute query
-    query = "select cluster_name from ngas_hosts where host_id={0}"
-    logger.debug("Executing SQL query to get local cluster name: %s", query)
-    cluster_name = srvObj.getDb().query2(query, args=(srvObj.getHostId(),))
+    sql = "select cluster_name from ngas_hosts where host_id = {0}"
+    logger.debug("Executing SQL query to get local cluster name: %s", sql)
+    cluster_name = ngams_server.getDb().query2(sql, args=(ngams_server.getHostId(),))
     cluster_name = str(cluster_name[0][0])
     logger.debug("Local cluster name: %s", cluster_name)
-
-    # Return cluster_name
     return cluster_name
 
 
-def get_full_qualified_name(srvObj):
+def get_fully_qualified_name(ngams_server):
     """
-    Get full qualified server name for the input NGAS server object
-
-    INPUT:
-        srvObj  ngamsServer, Reference to NG/AMS server class object
-
-    RETURNS:
-        fqdn    string, full qualified host name (host name + domain + port)
+    Get fully qualified server name for the input NGAS server object
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :return: string, full qualified host name (host name + domain + port)
     """
 
     # Get hots_id, domain and port using ngamsLib functions
-    host_id = srvObj.getHostId()
+    host_id = ngams_server.getHostId()
     simple_hostname = host_id.split('.')[0]
     domain = ngamsLib.getDomain()
-    port = str(srvObj.getCfg().getPortNo())
+    port = str(ngams_server.getCfg().getPortNo())
     # Concatenate all elements to construct full qualified name
     # Notice that host_id may contain port number
     fqdn = (simple_hostname.rsplit(":"))[0] + "." + domain + ":" + port
-
-    # Return full qualified server name
     return fqdn
 
 
-def get_active_source_nodes(srvObj, current_iteration, cluster_name="none", full_qualified_name="none"):
+def get_active_source_nodes(ngams_server, current_iteration, cluster_name="none", fully_qualified_name=None):
     """
-    Get active source nodes containing files to mirror
-    for input cluster name or full qualified server name
-
-    INPUT:
-    cluster_name        string, Name of the cluster to process mirroring tasks
-        full_qualified_name    string, Full qualified name of ngams server to process mirroring tasks
-    srvObj              ngamsServer, Reference to NG/AMS server class object
-
-    RETURNS:
-    active_source_nodes    list[string], List of active source nodes with files to mirror
+    Get active source nodes containing files to mirror for input cluster name or full qualified server name
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :param current_iteration: Current iteration
+    :param cluster_name: string, Name of the cluster to process mirroring tasks
+    :param fully_qualified_name: string, Full qualified name of ngams server to process mirroring tasks
+    :return: list[string], List of active source nodes with files to mirror
     """
-
     # Construct query
-    if (full_qualified_name == "none"):
-        query = "select source_host from ngas_mirroring_bookkeeping where status='READY' and target_cluster={0} and iteration = {1} group by source_host"
-        logger.debug("Executing SQL query to get active nodes with files to mirror for cluster %s: %s", cluster_name, query)
+    if fully_qualified_name is None:
+        sql = "select source_host from ngas_mirroring_bookkeeping " \
+              "where status='READY' and target_cluster = {0} and iteration = {1} group by source_host"
+        logger.debug("Executing SQL query to get active nodes with files to mirror for cluster %s: %s",
+                     cluster_name, sql)
         args = (cluster_name, current_iteration)
     else:
-        query = "select source_host from ngas_mirroring_bookkeeping where status='READY' and target_host={0} and iteration={1} group by source_host"
-        args = (full_qualified_name, current_iteration)
-        logger.debug("Executing SQL query to get active nodes with files to mirror for local server %s: %s", full_qualified_name, query)
+        sql = "select source_host from ngas_mirroring_bookkeeping " \
+              "where status='READY' and target_host = {0} and iteration = {1} group by source_host"
+        args = (fully_qualified_name, current_iteration)
+        logger.debug("Executing SQL query to get active nodes with files to mirror for local server %s: %s",
+                     fully_qualified_name, sql)
 
     # Execute query
-    source_nodes = srvObj.getDb().query2(query, args=args)
+    source_nodes = ngams_server.getDb().query2(sql, args=args)
 
     # Re-dimension query results array and check status
     active_source_nodes = []
@@ -208,28 +181,22 @@ def get_active_source_nodes(srvObj, current_iteration, cluster_name="none", full
         else:
             logger.debug("Source node %s is not ONLINE. Not considering for this mirroring iteration", node[0])
 
-    # Return result
     return active_source_nodes
 
 
-def get_active_target_nodes(cluster_name, current_iteration, srvObj):
+def get_active_target_nodes(cluster_name, current_iteration, ngams_server):
     """
     Get active target nodes ready to process mirroring tasks
-
-    INPUT:
-        cluster_name        string, Name of the cluster to process mirroring tasks
-    srvObj              ngamsServer, Reference to NG/AMS server class object
-
-    RETURNS:
-        active_target_nodes    list[string], List of active target nodes with files to mirror
+    :param cluster_name: string, Name of the cluster to process mirroring tasks
+    :param current_iteration: Current iteration
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :return: list[string], List of active target nodes with files to mirror
     """
+    sql = "select target_host from ngas_mirroring_bookkeeping " \
+          "where status = 'READY' and target_cluster = {0} and iteration = {1} group by target_host"
+    logger.debug("Executing SQL query to get active nodes with files to mirror for cluster %s: %s", cluster_name, sql)
 
-    # Construct query
-    query = "select target_host from ngas_mirroring_bookkeeping where status='READY' and target_cluster={0} and iteration = {1} group by target_host"
-    logger.debug("Executing SQL query to get active nodes with files to mirror for cluster %s: %s", cluster_name,query)
-
-    # Execute query
-    target_nodes = srvObj.getDb().query2(query, args=(cluster_name, current_iteration))
+    target_nodes = ngams_server.getDb().query2(sql, args=(cluster_name, current_iteration))
 
     # Re-dimension query results array and check status
     active_target_nodes = []
@@ -237,132 +204,122 @@ def get_active_target_nodes(cluster_name, current_iteration, srvObj):
         if ngams_server_status(node[0]):
             active_target_nodes.append(node[0])
         else:
-            removeTasks(node[0], cluster_name, srvObj)
+            remove_tasks(node[0], cluster_name, ngams_server)
 
-    # Log info
-    logger.debug("Active nodes found in cluster %s: %s", cluster_name,str(active_target_nodes))
-
-    # Return result
+    logger.debug("Active nodes found in cluster %s: %s", cluster_name, str(active_target_nodes))
     return active_target_nodes
 
 
 def ngams_server_status(ngams_server):
     """
     Check NGAMS server status
-
-    INPUT:
-        ngams_server    string, Full qualified name of ngams_server
-
-    RETURNS:
-    status         bool, True if active False if unactive
+    :param ngams_server: string, Full qualified name of ngams_server
+    :return: bool, True if active False if inactive
     """
-
     try:
         host, port = ngams_server.split(":")
         response = ngamsHttpUtils.httpGet(host, int(port), 'STATUS')
         with contextlib.closing(response):
             return b'ONLINE' in response.read()
-    except:
+    except Exception:
         logger.info("Problem trying to reach %s, setting status to OFFLINE (0)", ngams_server)
         return False
 
 
-def removeTasks(ngamsServer, clusterName, srvObj):
-    logger.warning("%s has gone OFFLINE. Marking all it's pending fetches as ABORTED so that other nodes can take over.", ngamsServer)
-    sql = "update ngas_mirroring_bookkeeping"
-    sql += " set status = 'ABORTED'"
-    sql += " where status in ('READY', 'FETCHING', 'TORESUME')"
-    sql += " and target_host = {0} and target_cluster = {1}"
-    srvObj.getDb().query2(sql, args=(ngamsServer, clusterName))
+def remove_tasks(target_host, cluster_name, ngams_server):
+    logger.warning("Server %s has gone OFFLINE. Marking all of it's pending fetches as ABORTED so that other nodes " 
+                   "can take over.", target_host)
+    sql = "update ngas_mirroring_bookkeeping " \
+          "set status = 'ABORTED' " \
+          "where status in ('READY', 'FETCHING', 'TORESUME') and target_host = {0} and target_cluster = {1}"
+    ngams_server.getDb().query2(sql, args=(target_host, cluster_name))
 
-def get_list_mirroring_tasks(currentIteration, source_node, target_node, srvObj):
+
+def get_list_mirroring_tasks(current_iteration, source_node, target_node, ngams_server):
     """
-    Check pending mirroring tasks in the ngas_bookkeeping
-    table assigned to the input host name
-
-    INPUT:
-        source_node     string, Node source of the files to be mirrored
-        target_node     string, Node target of the files to be mirrored
-        srvObj          ngamsServer, Reference to NG/AMS server class object
-
-    RETURNS:
-        mirroring_tasks list[string], List of files to be mirrored from the source_node to the target_node
+    Check pending mirroring tasks in the ngas_bookkeeping table assigned to the input host name
+    :param current_iteration: Current iteration
+    :param source_node: string, Node source of the files to be mirrored
+    :param target_node: string, Node target of the files to be mirrored
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :return: list[string], List of files to be mirrored from the source_node to the target_node
     """
-
-    # pull out the fields from the mirroring bookkeeping table that we may need in order to fetch files.
-    # the individual fields are passed around and eventually formed into a command in process_mirroring_tasks
-    query = "select file_size, staging_file, rowid, "
-    query += "format, checksum, checksum_plugin, source_host, disk_id, "
-    query += "host_id, file_version, file_id"
-    query += " from ngas_mirroring_bookkeeping"
-    query += " where source_host={0} and target_host={1}"
-    query += " and iteration = {2} and status='READY'"
-    query += " order by file_size"
+    # Pull out the fields from the mirroring bookkeeping table that we may need in order to fetch files.
+    # The individual fields are passed around and eventually formed into a command in process_mirroring_tasks
+    sql = "select file_size, staging_file, rowid, format, checksum, " \
+          "checksum_plugin, source_host, disk_id, host_id, file_version, file_id " \
+          "from ngas_mirroring_bookkeeping " \
+          "where source_host = {0} and target_host = {1} and iteration = {2} and status = 'READY' order by file_size"
 
     # Execute query to get mirroring tasks list
-    logger.debug("Executing SQL query to get list of mirroring tasks from (%s) to (%s): %s",
-                 source_node, target_node, query)
-    args = (source_node, target_node, currentIteration)
-    return srvObj.getDb().query2(query, args=args)
+    logger.debug("Executing SQL query to get list of mirroring tasks from (%s) to (%s): %s", source_node,
+                 target_node, sql)
+    args = (source_node, target_node, current_iteration)
+    return ngams_server.getDb().query2(sql, args=args)
 
 
-def get_num_download_threads_in_use(currentIteration, target_node, srv_obj):
-    # count the number of files which are currently being downloaded. This is not completely accurate
-    # of course - we can issue this select while we are between downloading files. This is especially
-    # likely if the size of the files are small. However it's an easy way to roughly gauge the
-    # number of files being downloaded, without major changes, and much better than the previous
-    # algorithm.
-    query = "select count(file_id) "
-    query += " from ngas_mirroring_bookkeeping"
-    query += " where target_host={0}"
-    query += " and iteration < {1} and status = 'FETCHING'"
+def get_num_download_threads_in_use(current_iteration, target_node, ngams_server):
+    """
+    Count the number of files which are currently being downloaded. This is not completely accurate of course - we can
+    issue this select while we are between downloading files. This is especially likely if the size of the files are
+    small.
+    However it's an easy way to roughly gauge the number of files being downloaded, without major changes, and much
+    better than the previous algorithm.
+    :param current_iteration:
+    :param target_node: string, Node target of the files to be mirrored
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :return: string, Backlog size
+    """
+    sql = "select count(file_id) from ngas_mirroring_bookkeeping " \
+          "where target_host = {0}  and iteration < {1} and status = 'FETCHING'"
 
     # Execute query to get mirroring tasks list
-    logger.debug("Executing SQL query to get number of download threads currently mirroring files to node %s", target_node)
-    backlog_size = srv_obj.getDb().query2(query, args=(target_node, currentIteration))[0][0]
-    logger.info('backlog: %s', backlog_size)
-
+    logger.debug("Executing SQL query to get number of download threads currently mirroring files to node %s",
+                 target_node)
+    backlog_size = ngams_server.getDb().query2(sql, args=(target_node, current_iteration))[0][0]
+    logger.info('Backlog size: %s', backlog_size)
     # Return mirroring tasks list
     return backlog_size
 
 
-def revert_mirroring_bookkeeping_entries(current_iteration, target_node, srv_obj):
-    sql = "delete from ngas_mirroring_bookkeeping"
-    sql += " where target_host=:targetNode"
-    sql += " and iteration = :iteration and status = 'READY'"
-    srv_obj.getDb().query2(sql, args=(target_node, current_iteration))
+def revert_mirroring_bookkeeping_entries(current_iteration, target_node, ngams_server):
+    sql = "delete from ngas_mirroring_bookkeeping " \
+          "where target_host = :targetNode and iteration = :iteration and status = 'READY'"
+    ngams_server.getDb().query2(sql, args=(target_node, current_iteration))
 
 
-def reorder_list_of_mirroring_tasks_for_target(currentIteration, source_nodes_list,target_node,mirroring_tasks_list,srvObj):
-
+def reorder_list_of_mirroring_tasks_for_target(current_iteration, source_nodes_list, target_node,
+                                               mirroring_tasks_list, ngams_server):
     # Construct query to get average file size and number of tasks
     args = [target_node]
-    query = "select count(*), sum(file_size/(1024*1024))/count(*) from ngas_mirroring_bookkeeping where target_host = {}"
-    query += " and (1 = 0"
+    sql = "select count(*), sum(file_size/(1024*1024)) / count(*) " \
+          "from ngas_mirroring_bookkeeping " \
+          "where target_host = {} and (1 = 0"
     if source_nodes_list:
         for node in source_nodes_list:
-            query += " or source_host = {}"
+            sql += " or source_host = {}"
             args.append(node)
-    query += ")"
-    query += " and status='READY' and iteration = {}"
-    args.append(currentIteration)
+    sql += ") and status='READY' and iteration = {}"
+    args.append(current_iteration)
 
     # Execute query to get average file size and number of tasks
-    logger.debug("Executing SQL query to get average file size and number of mirroring tasks to (%s): %s", target_node, query)
-    result = srvObj.getDb().query2(query, args=args)
+    logger.debug("Executing SQL query to get average file size and number of mirroring tasks to (%s): %s",
+                 target_node, sql)
+    result = ngams_server.getDb().query2(sql, args=args)
     total_tasks = int(result[0][0])
-    target_avg_file_size = 0
-    # if we divide by zero in the oracle query then we get an empty result back for average file size
-    if (total_tasks > 0):
-        target_avg_file_size = float(result[0][1])
-    logger.debug("Average file size and number of mirroring tasks to (%s): nTasks=%s Avg[MB]=%s", target_node,str(total_tasks),str(target_avg_file_size))
+    target_average_file_size = 0
+    # If we divide by zero in the oracle query then we get an empty result back for average file size
+    if total_tasks > 0:
+        target_average_file_size = float(result[0][1])
+    logger.debug("Average file size and number of mirroring tasks to target node (%s): total tasks = %d, " 
+                 "average[MB] = %f", target_node, total_tasks, target_average_file_size)
 
-    n_sources = len(source_nodes_list)
-    sources_iterator = range(n_sources)
-    ascending_index = range(n_sources)
-    descending_index = range(n_sources)
-    source_total_tasks = range(n_sources)
-    source_processed_tasks = range(n_sources)
+    num_sources = len(source_nodes_list)
+    sources_iterator = range(num_sources)
+    ascending_index = range(num_sources)
+    descending_index = range(num_sources)
+    source_total_tasks = range(num_sources)
+    source_processed_tasks = range(num_sources)
     reordered_mirroring_tasks_list = collections.deque()
     next_source_ascending_index = 0
     next_source_descending_index = 0
@@ -373,56 +330,52 @@ def reorder_list_of_mirroring_tasks_for_target(currentIteration, source_nodes_li
         source_total_tasks[ith_source] = len(mirroring_tasks_list[ith_source])
         source_processed_tasks[ith_source] = 0
 
-    avg_file_size = 0
+    average_file_size = 0
     processed_tasks = 0
     processed_size = 0
 
-    logger.debug("Start reordering mirroring tasks for %s" , target_node)
+    logger.debug("Start reordering mirroring tasks for %s", target_node)
 
-    # process files one after the other
-    #     if (
+    # Process files one after the other
     iteration = 0
-    # this a complex algorithm and I've seen it hang on occasion. This is to prevent an infinite loop occurring.
-    # There are too many variables for me to reason about this and too little time. We will deploy and watch out
-    # for iterations where not all files are mirrored.
-    # the 2M iterations count has the side effect that only 1M files will be processed in a single
-    # iteration
+    # This a complex algorithm and I've seen it hang on occasion. This is to prevent an infinite loop occurring.
+    # There are too many variables for me to reason about this and too little time.
+    # We will deploy and watch out for iterations where not all files are mirrored.
+    # The 2M iterations count has the side effect that only 1M files will be processed in a single iteration
     emergency_breakpoint = 2000000
-    while (processed_tasks < total_tasks):
-        logger.debug("outer loop iteration: %d", iteration)
+    while processed_tasks < total_tasks:
+        logger.debug("Outer loop iteration: %d", iteration)
         iteration += 1
-        if (iteration > emergency_breakpoint):
-            logger.critical("re-ordering is not exiting - performing an emergency exit")
+        if iteration > emergency_breakpoint:
+            logger.critical("Re-ordering is not exiting - performing an emergency exit")
             break
 
-        # Add big file if the current avg is below the total avg
-        logger.debug(4, "average: %f/%f", avg_file_size, target_avg_file_size)
-        next_source = 0
-        task_index = None
-        smallFile = (avg_file_size < target_avg_file_size)
-        if (smallFile):
+        # Add big file if the current average below the total average
+        logger.debug("Average: %f/%f", average_file_size, target_average_file_size)
+        small_file = average_file_size < target_average_file_size
+        if small_file:
             next_source = next_source_descending_index
-            next_source_descending_index = (next_source_descending_index + 1) % n_sources
+            next_source_descending_index = (next_source_descending_index + 1) % num_sources
             task_index = descending_index[next_source]
         else:
             next_source = next_source_ascending_index
-            next_source_ascending_index = (next_source_ascending_index + 1) % n_sources
+            next_source_ascending_index = (next_source_ascending_index + 1) % num_sources
             task_index = ascending_index[next_source]
 
         logger.debug("    next_source: %d", next_source)
         processed = source_processed_tasks[next_source]
         total = source_total_tasks[next_source]
-        if (processed >= total):
-            logger.info("all tasks for %s have been assigned already", str(source_nodes_list[next_source]))
+        if processed >= total:
+            logger.info("All tasks for %s have been assigned already", str(source_nodes_list[next_source]))
         else:
-            completion = calculatePercentageDone(processed, total)
-            total_completion = calculatePercentageDone(processed_tasks + 1, total_tasks)
-            logger.debug("if completion: %f > %f", completion, total_completion)
-            # this will fail if there is a single source, or group of sources, where the completion is always
+            completion = calculate_percentage_done(processed, total)
+            total_completion = calculate_percentage_done(processed_tasks + 1, total_tasks)
+            logger.debug("If completion: %f > %f", completion, total_completion)
+            # This will fail if there is a single source, or group of sources, where the completion is always
             # greater than the total projected completion
-            if (completion > total_completion):
+            if completion > total_completion:
                 logger.debug("    Skipping next file from source %d -> Completion :%f%% Total Completion: %f%%",
-                        next_source, completion, total_completion)
+                             next_source, completion, total_completion)
             else:
                 mirroring_task = mirroring_tasks_list[next_source][task_index]
                 logger.debug("    mirroring_task: %s", str(mirroring_task))
@@ -433,10 +386,11 @@ def reorder_list_of_mirroring_tasks_for_target(currentIteration, source_nodes_li
 
                 source_processed_tasks[next_source] += 1
                 processed_tasks += 1
-                avg_file_size = processed_size / processed_tasks
-                logger.debug("    Appending file: tasks=%d source=%d index=%d processed=%f total=%f size=%f MB avg=%f",
-                             processed_tasks, next_source, task_index, processed, total, file_size, avg_file_size)
-                if (smallFile):
+                average_file_size = processed_size / processed_tasks
+                logger.debug("    Appending file: tasks=%d, source=%d, index=%d, processed=%f, total=%f, " 
+                             "size=%f MB, average=%f MB", processed_tasks, next_source, task_index, processed, total,
+                             file_size, average_file_size)
+                if small_file:
                     descending_index[next_source] -= 1
                 else:
                     ascending_index[next_source] += 1
@@ -447,112 +401,100 @@ def reorder_list_of_mirroring_tasks_for_target(currentIteration, source_nodes_li
         logger.debug("    1 asc:       %s", str(ascending_index))
 
     logger.info("Done reordering mirroring tasks for %s", target_node)
-
-    # Return reordered lists
     return reordered_mirroring_tasks_list
 
-def calculatePercentageDone(numComplete, total):
+
+def calculate_percentage_done(num_complete, total):
     completion = 1.0
-    if (float(total) > 0.0):
-        completion = float(numComplete) / float(total)
+    if float(total) > 0.0:
+        completion = float(num_complete) / float(total)
     return completion
 
-def get_sublist_mirroring_tasks(tasks, n_threads, ith_thread, reverse_flag):
+
+def get_sublist_mirroring_tasks(tasks, num_threads, ith_thread, reverse_flag):
     """
-    Generate a sub-list containing the ith-element of
-    every n elements. Reverse the list is specified.
-
-    INPUT:
-        list            list, Original list
-        n_threads      int, Number of threads
-        ith_thread     int, pos-th to be selected
-        reverse_flag   bool, True if the list has to be reversed
-
-    RETURNS:
-        filtered_list   list, Filtered list
+    Generate a sub-list containing the ith-element of every n elements. Reverse the list is specified.
+    :param tasks: list, Original list
+    :param num_threads: int, Number of threads
+    :param ith_thread: int, pos-th to be selected
+    :param reverse_flag: bool, True if the list has to be reversed
+    :return: list, Filtered list
     """
-
-    # Filter list loop
     filtered_list = []
     for i, element in enumerate(tasks):
-        if ((i % n_threads) == ith_thread): filtered_list.append(element)
-
-    # Reverse if specified
-    if (reverse_flag): filtered_list.reverse()
-
-    # Return filter list
+        if (i % num_threads) == ith_thread:
+            filtered_list.append(element)
+    if reverse_flag:
+        filtered_list.reverse()
     return filtered_list
 
 
-def process_mirroring_tasks(mirroring_tasks_queue,target_node,ith_thread,n_tasks,srvObj):
+def process_mirroring_tasks(mirroring_tasks_queue, target_node, ith_thread, num_tasks, ngams_server):
     """
     Process mirroring tasks described in the input mirroring_tasks list
-
-    INPUT:
-        mirroring_tasks_queue    Queue of the mirroring tasks assigned to the input server
-    target_node        string, Full qualified name of the target node
-    ith_thread        int, Thread number
-        n_tasks            int, Initial size of the queue
-    srvObj            ngamsServer, Reference to NG/AMS server class object
-
-    RETURNS:            Void
+    :param mirroring_tasks_queue: Queue of the mirroring tasks assigned to the input server
+    :param target_node: string, Full qualified name of the target node
+    :param ith_thread: int, Thread number
+    :param num_tasks: int, Initial size of the queue
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
     """
-
-    logger.debug("Inside mirror worker worker %d to mirror files to %s", ith_thread,target_node)
-
+    logger.debug("Inside mirror worker worker %d to mirror files to %s", ith_thread, target_node)
     try:
         # Loop on the mirroring_tasks_queue
-        while 1:
+        while True:
             # Get tasks from queue
-            if (len(mirroring_tasks_queue)):
+            if len(mirroring_tasks_queue):
                 try:
-                    if (ith_thread % 2): item = mirroring_tasks_queue.pop()
-                    else: item = mirroring_tasks_queue.popleft()
-                except: break
-            else: break
-            # get all the fields we're interested in and form them into a command to fetch the files.
-            # these fields were extracted in get_list_mirroring_tasks()
-            logger.debug("next task: %r", item)
+                    if ith_thread % 2:
+                        item = mirroring_tasks_queue.pop()
+                    else:
+                        item = mirroring_tasks_queue.popleft()
+                except Exception:
+                    break
+            else:
+                break
+
+            # Get all the fields we are interested in and form them into a command to fetch the files.
+            # These fields were extracted in get_list_mirroring_tasks()
+            logger.debug("Next task: %r", item)
             staging_file = str(item[1])
-            mimeType = str(item[3])
+            mime_type = str(item[3])
             checksum = str(item[4])
             checksum_plugin = str(item[5])
             rowid = str(item[2])
             file_id = str(item[10])
-            fileSize = str(item[0])
-            fileInfo = {}
-            fileInfo['sourceHost'] = str(item[6])
-            fileInfo['diskId'] = str(item[7])
-            fileInfo['hostId'] = str(item[8])
-            fileInfo['fileVersion'] = str(item[9])
-            fileInfo['fileId'] = file_id
+            file_size = str(item[0])
+            file_info = {}
+            file_info['sourceHost'] = str(item[6])
+            file_info['diskId'] = str(item[7])
+            file_info['hostId'] = str(item[8])
+            file_info['fileVersion'] = str(item[9])
+            file_info['fileId'] = file_id
 
-            logger.info("Processing mirroring task (Target node: %s, file size: %s, Thread: %d) file info: %s",
-                        target_node, fileSize, ith_thread, str(fileInfo))
-            # Initialize ngamsReqProps object by just specifing the fileURI and the mime type
-            reqPropObj = ngamsReqProps.ngamsReqProps()
-            reqPropObj.setMimeType(mimeType)
-            reqPropObj.checksum = checksum
-            reqPropObj.checksum_plugin = checksum_plugin
-            reqPropObj.fileinfo = fileInfo
-            reqPropObj.setSize(fileSize)
+            logger.info("Processing mirroring task (target node: %s, file size: %s, thread: %d) file info: %s",
+                        target_node, file_size, ith_thread, str(file_info))
+            # Initialize ngamsReqProps object by just specifying the file URI and the mime-type
+            request_properties = ngamsReqProps.ngamsReqProps()
+            request_properties.setMimeType(mime_type)
+            request_properties.checksum = checksum
+            request_properties.checksum_plugin = checksum_plugin
+            request_properties.fileinfo = file_info
+            request_properties.setSize(file_size)
 
             # Start clock
             start = time.time()
-            (stgFilename, targetDiskInfo) = calculateStagingName(srvObj, file_id, staging_file)
-            reqPropObj.setStagingFilename(stgFilename)
-            reqPropObj.setTargDiskInfo(targetDiskInfo)
+            (staging_filename, target_disk_info) = calculate_staging_name(ngams_server, file_id, staging_file)
+            request_properties.setStagingFilename(staging_filename)
+            request_properties.setTargDiskInfo(target_disk_info)
             try:
                 # Construct query to update ingestion date, ingestion time and status
-                query = "update ngas_mirroring_bookkeeping set status='FETCHING', "
-                query += "staging_file = {0}, "
-                query += "attempt = nvl(attempt + 1, 1) "
-                query += "where rowid = {1}"
+                sql = "update ngas_mirroring_bookkeeping " \
+                      "set status = 'FETCHING', staging_file = {0}, attempt = nvl(attempt + 1, 1) " \
+                      "where rowid = {1}"
                 # Add query to the queue
-                srvObj.getDb().query2(query, args=(reqPropObj.getStagingFilename(), rowid))
-
+                ngams_server.getDb().query2(sql, args=(request_properties.getStagingFilename(), rowid))
                 logger.info("Mirroring file: %s", file_id)
-                ngamsCmd_MIRRARCHIVE.handleCmd(srvObj,reqPropObj)
+                ngamsCmd_MIRRARCHIVE.handleCmd(ngams_server, request_properties)
                 status = "SUCCESS"
             except ngamsFailedDownloadException.FailedDownloadException:
                 # Something bad happened...
@@ -565,135 +507,130 @@ def process_mirroring_tasks(mirroring_tasks_queue,target_node,ith_thread,n_tasks
                 logger.exception("Failed to fetch %s - will try to resume on next iteration", file_id)
                 status = "TORESUME"
             except Exception:
-                # this clause should never be reached
+                # This clause should never be reached
                 logger.exception("Fetch failed in an unexpected way")
                 status = "FAILURE"
 
             # Get time elapsed
             elapsed_time = (time.time() - start)
+
             # Construct query to update ingestion date, ingestion time and status
-            query = "update ngas_mirroring_bookkeeping set status = {0},"
-            if (status != 'TORESUME'): query += "staging_file = null, "
-            query += "ingestion_date = {1},"
-            query += "ingestion_time = nvl(ingestion_time, 0.0) + {2} "
-            query += "where rowid = {3}"
+            sql = "update ngas_mirroring_bookkeeping set status = {0},"
+            if status != 'TORESUME':
+                sql += "staging_file = null, "
+            sql += "ingestion_date = {1}, ingestion_time = nvl(ingestion_time, 0.0) + {2} " \
+                   "where rowid = {3}"
             args = (status, toiso8601(fmt=FMT_DATETIME_NOMSEC) + ":000", elapsed_time, rowid)
-            srvObj.getDb().query2(query, args=args)
+            ngams_server.getDb().query2(sql, args=args)
 
             # Log message for mirroring task processed
-            completion = 100*(n_tasks - len(mirroring_tasks_queue))/float(n_tasks)
+            completion = 100 * (num_tasks - len(mirroring_tasks_queue)) / float(num_tasks)
             logger.info("Mirroring task (Target node: %s Thread: %d) processed in %fs (%s), completion: %f%%: %s",
-                        target_node, ith_thread, elapsed_time, status, completion, str(fileInfo))
-
+                        target_node, ith_thread, elapsed_time, status, completion, str(file_info))
         logger.info("Mirroring Worker complete")
     except Exception:
         logger.exception("Error while running mirroring worker")
-
-    # Return Void
     return
 
-def calculateStagingName(srvObj, fileId, existingStagingFile):
-    # Generate staging filename.
-    # as of v2016.06 we either have a staging filename or just the disk volume to which the file should be mirrorired.
-    # How can we tell which is which? staging filenames all include the character string "___"
-    stgFilename = None
-    logger.debug('existing staging file: |%s|', existingStagingFile)
-    if existingStagingFile == "None":
-        logger.error('trying to mirror a file where the staging file has not been set. This should no longer happen')
-    elif "___" in existingStagingFile:
-        logger.info("An existing staging file was specified: %s", existingStagingFile)
-        if os.path.exists(existingStagingFile):
-            logger.info("the file still exists on disk")
-            stgFilename = existingStagingFile
-            mountPoint = stgFilename.split(NGAMS_STAGING_DIR)[0][:-1]
-            logger.info('mount point: %s', mountPoint)
-            targDiskInfo = getMountedDiskInfo(srvObj, mountPoint)
-            logger.info('disk info: %s', str(targDiskInfo))
+
+def calculate_staging_name(ngams_server, file_id, existing_staging_file):
+    """
+    Generate staging filename.
+    As of v2016.06 we either have a staging filename or just the disk volume to which the file should be mirrored
+    How can we tell which is which? staging filenames all include the character string "___"
+    """
+    staging_filename = None
+    logger.debug('Existing staging file: |%s|', existing_staging_file)
+    if existing_staging_file == "None":
+        logger.error('Trying to mirror a file where the staging file has not been set. This should no longer happen')
+    elif "___" in existing_staging_file:
+        logger.info("An existing staging file was specified: %s", existing_staging_file)
+        if os.path.exists(existing_staging_file):
+            logger.info("The file still exists on disk")
+            staging_filename = existing_staging_file
+            mount_point = staging_filename.split(NGAMS_STAGING_DIR)[0][:-1]
+            logger.info('Staging file mount point: %s', mount_point)
+            target_disk_info = get_mounted_disk_info(ngams_server, mount_point)
+            logger.info('Staging file disk info: %s', str(target_disk_info))
         else:
-            logger.info("the file no longer exists on disk")
+            logger.info("The staging file no longer exists on disk")
     else:
-        logger.info('staging file does not exist, only the mount dir: %s', existingStagingFile)
-        baseName = os.path.basename(fileId)
-        stgFilename = os.path.join("/", existingStagingFile,
-                               NGAMS_STAGING_DIR,
-                               genUniqueId() + "___" + baseName)
-        targDiskInfo = getMountedDiskInfo(srvObj, existingStagingFile)
-    # I do not expect this case to be used any more from v2016.06 onwards
-    # leave it here for the moment, but delete ASAP
-    if stgFilename == None:
-        logger.error('reached some old code which we shouldnt have reached');
-        baseName = os.path.basename(fileId)
-        targDiskInfo = getTargetVolume(srvObj)
-        stgFilename = os.path.join("/", targDiskInfo.getMountPoint(),
-                               NGAMS_STAGING_DIR,
-                               genUniqueId() + "___" + baseName)
-    return (stgFilename, targDiskInfo)
+        logger.info('Staging file does not exist, only the mount directory: %s', existing_staging_file)
+        base_name = os.path.basename(file_id)
+        staging_filename = os.path.join("/", existing_staging_file, NGAMS_STAGING_DIR,
+                                        genUniqueId() + "___" + base_name)
+        target_disk_info = get_mounted_disk_info(ngams_server, existing_staging_file)
+
+    # I do not expect this case to be used any more from v2016.06 onwards leave it here for the moment, but delete ASAP
+    if staging_filename is None:
+        logger.error('Reached some old code which we should not have reached')
+        base_name = os.path.basename(file_id)
+        target_disk_info = get_target_volume(ngams_server)
+        staging_filename = os.path.join("/", target_disk_info.getMountPoint(), NGAMS_STAGING_DIR,
+                                        genUniqueId() + "___" + base_name)
+    return staging_filename, target_disk_info
 
 
-GET_AVAIL_VOLS_QUERY = "SELECT %s FROM ngas_disks nd WHERE completed=0 AND " +\
-                       "host_id={0} order by available_mb desc"
-
-# dictionary((hostname, mountpoint) -> diskInfo)
+# TODO: remove this global variables
 _cached_disk_info = {}
-def getTargetVolume(srvObj):
+
+
+def get_target_volume(ngams_server):
     """
     Get the volume with most space available
-
-    srvObj:         Reference to NG/AMS server class object (ngamsServer).
-
-    Returns:        Target volume object or None (ngamsDiskInfo | None).
+    :param ngams_server: Reference to NG/AMS server class object (ngamsServer)
+    :return: Target volume object or None (ngamsDiskInfo | None)
     """
-
-    sqlQuery = GET_AVAIL_VOLS_QUERY % ngamsDbCore.getNgasDisksCols()
-    res = srvObj.getDb().query2(sqlQuery, args=(srvObj.getHostId(),))
-    if not res:
+    sql = "select %s from ngas_disks nd where completed = 0 and host_id = {0} order by available_mb desc"\
+          % ngamsDbCore.getNgasDisksCols()
+    result = ngams_server.getDb().query2(sql, args=(ngams_server.getHostId(),))
+    if not result:
         return None
     else:
-        return ngamsDiskInfo.ngamsDiskInfo().unpackSqlResult(res[0])
+        return ngamsDiskInfo.ngamsDiskInfo().unpackSqlResult(result[0])
 
-def getMountedDiskInfo(srvObj, mountPoint):
-    diskinfo = _cached_disk_info.get((srvObj.getHostId(), mountPoint), None)
-    if diskinfo == None:
-        sqlQuery = "SELECT %s FROM ngas_disks nd WHERE mount_point = {0} and host_id = {1}" % ngamsDbCore.getNgasDisksCols()
-        res = srvObj.getDb().query2(sqlQuery, args = (mountPoint, srvObj.getHostId()))
-        if not res:
-            diskinfo = None
+
+def get_mounted_disk_info(ngams_server, mount_point):
+    disk_info = _cached_disk_info.get((ngams_server.getHostId(), mount_point), None)
+    if disk_info is None:
+        sql = "select %s from ngas_disks nd where mount_point = {0} and host_id = {1}"\
+              % ngamsDbCore.getNgasDisksCols()
+        result = ngams_server.getDb().query2(sql, args=(mount_point, ngams_server.getHostId()))
+        if not result:
+            disk_info = None
         else:
-            diskinfo = ngamsDiskInfo.ngamsDiskInfo().unpackSqlResult(res[0])
-            _cached_disk_info[(srvObj.getHostId(), mountPoint)] = diskinfo
-    return diskinfo
+            disk_info = ngamsDiskInfo.ngamsDiskInfo().unpackSqlResult(result[0])
+            _cached_disk_info[(ngams_server.getHostId(), mount_point)] = disk_info
+    return disk_info
 
 
-def multithreading_mirroring(source_nodes_list, n_threads, rx_timeout, current_iteration, srvObj):
+def multithreading_mirroring(source_nodes_list, num_threads, current_iteration, ngams_server):
     """
-    Creates n threads per source node and target node to process the corresponding mirroring tasks
-    Each thread starts from big files or small files alternating
-
-    INPUT:
-    source_nodes_list    list[string], List of active source nodes in the source cluster
-    n_threads        int, Number of threads per source-target connection
-        srvObj              ngamsServer, Reference to NG/AMS server class object
-
-    RETURNS:            Void
+    Creates multiple threads per source node and target node to process the corresponding mirroring tasks. Each thread
+    starts from big files or small files alternating.
+    :param source_nodes_list: list[string], List of active source nodes in the source cluster
+    :param num_threads: int, Number of threads per source-target connection
+    :param current_iteration: Current iteration
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
     """
+    target_node = get_fully_qualified_name(ngams_server)
 
-    # Get local host name
-    target_node = get_full_qualified_name(srvObj)
-
-    # how many files do we still have to download from previous iterations?
-    n_threads_in_use = get_num_download_threads_in_use(current_iteration, target_node, srvObj)
-    available_threads_for_mirroring = n_threads - n_threads_in_use
+    # How many files do we still have to download from previous iterations?
+    num_threads_in_use = get_num_download_threads_in_use(current_iteration, target_node, ngams_server)
+    available_threads_for_mirroring = num_threads - num_threads_in_use
     if available_threads_for_mirroring <= 0:
-        logger.info('there are no mirroring threads available for host %s (%d are allowed, %d are being used)', target_node, n_threads, n_threads_in_use)
-        # this is not stricly an error, merely a badly implemented feature:
-        # - the mirroring master only sends commands to the other nodes if it knows they have threads available
-        # - it works this out by looking at how many files are marked as 'FETCHING' in teh bookkeeping table
-        # - but it could query that table while the the node is preparing to download, or has just finished
-        # as a result the master could tell the node to mirror, but the node says "no, no threads available"
+        logger.info("There are no mirroring threads available for host %s (%d are allowed, %d are being used)",
+                    target_node, num_threads, num_threads_in_use)
+        # This is not strictly an error, merely a badly implemented feature:
+        # * the mirroring master only sends commands to the other nodes if it knows they have threads available
+        # * it works this out by looking at how many files are marked as 'FETCHING' in teh bookkeeping table
+        # * but it could query that table while the the node is preparing to download, or has just finished
+        # As a result the master could tell the node to mirror, but the node says "no, no threads available"
         # We don't want to mark the files as ERROR, or TORESUME. Let's just pretend that it didn't happen.
         # Otherwise our monitoring application becomes much more confusing to interpret.
-        logger.info('removing mirroring bookkeeping entries for node %s for iteration %d', target_node, current_iteration)
-        revert_mirroring_bookkeeping_entries(current_iteration, target_node, srvObj)
+        logger.info('Removing mirroring bookkeeping entries for node %s for iteration %d',
+                    target_node, current_iteration)
+        revert_mirroring_bookkeeping_entries(current_iteration, target_node, ngams_server)
         return
 
     # Get tasks from each target-source pair
@@ -701,24 +638,25 @@ def multithreading_mirroring(source_nodes_list, n_threads, rx_timeout, current_i
     # Get mirroring tasks from each source
     source_index = 0
     for source_node in source_nodes_list:
-        # Get mirroring taks list for this pair target-source
-        ith_source_mirroring_tasks_list = get_list_mirroring_tasks(current_iteration, source_node,target_node,srvObj)
+        # Get mirroring tasks list for this pair target-source
+        ith_source_mirroring_tasks_list = get_list_mirroring_tasks(current_iteration, source_node,
+                                                                   target_node, ngams_server)
         # Assign list to all sources mirroring tasks list
         all_sources_mirroring_tasks_list.append(ith_source_mirroring_tasks_list)
-        # Increase source index counter
         source_index += 1
 
     # Reorder lists to mix big/small files and put in queue format
-    mirroring_tasks_queue = reorder_list_of_mirroring_tasks_for_target(current_iteration, source_nodes_list, target_node,all_sources_mirroring_tasks_list,srvObj)
-
+    mirroring_tasks_queue = reorder_list_of_mirroring_tasks_for_target(current_iteration, source_nodes_list,
+                                                                       target_node, all_sources_mirroring_tasks_list,
+                                                                       ngams_server)
     # Start threads iterator
     threads_range = range(available_threads_for_mirroring)
     threads_list = []
 
     # Start multi-threading mirroring
     for ith_thread in threads_range:
-        logger.info("Inititalizing mirror worker %d to mirror files to %s", ith_thread+1, target_node)
-        ith_mirror_worker = mirror_worker(mirroring_tasks_queue, target_node, ith_thread + 1, srvObj)
+        logger.info("Initializing mirror worker %d to mirror files to %s", ith_thread + 1, target_node)
+        ith_mirror_worker = MirrorWorker(mirroring_tasks_queue, target_node, ith_thread + 1, ngams_server)
         ith_mirror_worker.start()
         threads_list.append(ith_mirror_worker)
 
@@ -726,31 +664,30 @@ def multithreading_mirroring(source_nodes_list, n_threads, rx_timeout, current_i
     for ith_thread in threads_list:
         ith_thread.join()
 
-    # Return Void
     return
 
 
-class mirror_worker(threading.Thread):
-    def __init__ (self,mirroring_tasks_queue,target_node,ith_thread,srvObj):
+class MirrorWorker(threading.Thread):
+
+    def __init__(self, mirroring_tasks_queue, target_node, ith_thread, ngams_server):
         threading.Thread.__init__(self)
         self.mirroring_tasks_queue = mirroring_tasks_queue
         self.total_tasks = len(mirroring_tasks_queue)
         self.target_node = target_node
         self.ith_thread = ith_thread
-        self.srvObj = srvObj
+        self.ngams_server = ngams_server
+
     def run(self):
-        process_mirroring_tasks(self.mirroring_tasks_queue,self.target_node,self.ith_thread,self.total_tasks,self.srvObj)
+        process_mirroring_tasks(self.mirroring_tasks_queue, self.target_node, self.ith_thread,
+                                self.total_tasks, self.ngams_server)
+
 
 def sort_target_nodes(target_nodes_list):
     """
     Sort target_nodes_list to balance priority
-
-    INPUT:
-        target_nodes_list       list[string], List of active target nodes in the target cluster
-
-    RETURNS:                    list[string], Sorted active target nodes list
+    :pram target_nodes_list: list[string], List of active target nodes in the target cluster
+    :return: list[string], Sorted active target nodes list
     """
-
     # Initialize machine/port dictionary
     machines_list = {}
     for target_node in target_nodes_list:
@@ -766,32 +703,25 @@ def sort_target_nodes(target_nodes_list):
     # Create sorted target nodes list
     found_one = True
     sorted_target_nodes_list = []
-    while (found_one):
+    while found_one:
         found_one = False
         for machine in machines_list:
-            if len(machines_list[machine])>0:
-                sorted_target_nodes_list.append(machine+':'+machines_list[machine].pop())
+            if len(machines_list[machine]) > 0:
+                # Add higher port (machines sort-descending)
+                sorted_target_nodes_list.append(machine + ':' + machines_list[machine].pop())
                 found_one = True
-
-    # Log info
-    logger.debug("Target nodes order to send MIRREXEC command: %s", str(sorted_target_nodes_list))    # Add higher port (machines sort-descending)
-
-    # Return sorted target nodes list
+    logger.debug("Target nodes order to send MIRREXEC command: %s", str(sorted_target_nodes_list))
     return sorted_target_nodes_list
 
 
-def distributed_mirroring(target_nodes_list,n_threads, rx_timeout, iteration):
+def distributed_mirroring(target_nodes_list, num_threads, rx_timeout, iteration):
     """
-    Send MIRREXEC command to each nodes in the target nodes
-    list in order to have a distributed mirroring process
-
-    INPUT:
-        target_nodes_list    list[string], List of active target nodes in the target cluster
-    n_threads        int, Number of threads per source-target connection
-
-    RETURNS:                Void
+    Send MIRREXEC command to each nodes in the target nodes list in order to have a distributed mirroring process
+    :param target_nodes_list: list[string], List of active target nodes in the target cluster
+    :param num_threads: int, Number of threads per source-target connection
+    :param rx_timeout: Socket timeout in seconds
+    :param iteration: Iteration
     """
-
     # Get sorted_target_nodes_list
     sorted_target_nodes_list = sort_target_nodes(target_nodes_list)
 
@@ -799,7 +729,7 @@ def distributed_mirroring(target_nodes_list,n_threads, rx_timeout, iteration):
     threads_list = []
     for target_node in sorted_target_nodes_list:
         # Initialize mirrexec_command_sender thread object
-        mirrexec_command_sender_obj = mirrexec_command_sender(target_node, n_threads, rx_timeout, iteration)
+        mirrexec_command_sender_obj = MirrexecCommandSender(target_node, num_threads, rx_timeout, iteration)
         # Add mirrexec_command_sender thread object to the list of threads
         threads_list.append(mirrexec_command_sender_obj)
         # Start mirrexec_command_sender thread object
@@ -809,44 +739,39 @@ def distributed_mirroring(target_nodes_list,n_threads, rx_timeout, iteration):
     for ith_thread in threads_list:
         ith_thread.join()
 
-    # Return Void
     return
 
-class mirrexec_command_sender(threading.Thread):
 
-    def __init__ (self,target_node,n_threads, rx_timeout, iteration):
+class MirrexecCommandSender(threading.Thread):
+
+    def __init__(self, target_node, num_threads, rx_timeout, iteration):
+        """
+        :param target_node: string, Target node to send MIRREXEC
+        :param num_threads: int, Number of threads per source-target connection
+        :param rx_timeout: int, Socket timeout time in seconds
+        :param iteration: int, Iteration
+        """
         threading.Thread.__init__(self)
         self.target_node = target_node
-        self.n_threads = n_threads
+        self.num_threads = num_threads
         self.rx_timeout = rx_timeout
         self.iteration = iteration
 
     def run(self):
         try:
             self.send_mirrexec_command()
-        except:
+        except Exception:
             logger.exception("MIRREXEC command failed")
 
     def send_mirrexec_command(self):
         """
         Send MIRREXEC command to the input source_node
-
-        INPUT:
-            source_node    string, Target node to send MIRREXEC
-            n_threads       int, Number of threads per source-target connection
-            rx_timeout        int, the socket timeout time in seconds
-
-        RETURNS:        Void
         """
-
-        # Print log info
-        logger.info("sending MIRREXEC command to %s with (n_threads=%d)", self.target_node, self.n_threads)
-
+        logger.info("Sending MIRREXEC command to %s with (n_threads=%d)", self.target_node, self.num_threads)
         try:
-
             host, port = self.target_node.split(":")
             pars = {
-                'n_threads': str(self.n_threads),
+                'n_threads': str(self.num_threads),
                 'rx_timeout': str(self.rx_timeout),
                 'iteration': str(self.iteration)
             }
@@ -855,19 +780,15 @@ class mirrexec_command_sender(threading.Thread):
             response = ngamsHttpUtils.httpGet(host, int(port), 'MIRREXEC', pars=pars, timeout=self.rx_timeout)
             with contextlib.closing(response):
                 failed = response.status != NGAMS_HTTP_SUCCESS or NGAMS_FAILURE in response.read()
-            elapsed_time = (time.time() - start)
+            elapsed_time = time.time() - start
 
-            # Print log info
             if failed:
-                logger.error("MIRREXEC command sent to %s with (n_threads=%d) was handled  with status FAILURE in %f [s]",
-                             self.target_node, self.n_threads, elapsed_time)
+                logger.error("MIRREXEC command sent to %s with (n_threads=%d) was handled with status FAILURE " 
+                             "in %f [s]", self.target_node, self.num_threads, elapsed_time)
             else:
-                logger.info("MIRREXEC command sent to %s with (n_threads=%d) was handled  with status SUCCESS in %f [s]",
-                            self.target_node, self.n_threads, elapsed_time)
-        except:
+                logger.info("MIRREXEC command sent to %s with (n_threads=%d) was handled with status SUCCESS in %f [s]",
+                            self.target_node, self.num_threads, elapsed_time)
+        except Exception:
             logger.exception("Problems sending MIRREXEC command to %s", self.target_node)
 
-        # Return Void
         return
-
-# EOF

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRREXEC.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRREXEC.py
@@ -776,11 +776,11 @@ class MirrexecCommandSender(threading.Thread):
                 'iteration': str(self.iteration)
             }
 
-            start = time.time()
+            start_time = time.time()
             response = ngamsHttpUtils.httpGet(host, int(port), 'MIRREXEC', pars=pars, timeout=self.rx_timeout)
             with contextlib.closing(response):
                 failed = response.status != NGAMS_HTTP_SUCCESS or NGAMS_FAILURE in response.read()
-            elapsed_time = time.time() - start
+            elapsed_time = time.time() - start_time
 
             if failed:
                 logger.error("MIRREXEC command sent to %s with (n_threads=%d) was handled with status FAILURE " 

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRRTABLE.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRRTABLE.py
@@ -19,7 +19,7 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
-#******************************************************************************
+# *****************************************************************************
 #
 # "@(#) $Id: ngamsCmd_MIRRTABLE.py,v 1.6 2010/06/22 18:55:14 awicenec Exp $"
 #
@@ -28,28 +28,29 @@
 # jagonzal  2009/12/14  Created
 #
 """
-NGAS Command Plug-In, implementing a command to fill the mirroring_bookkeping_table
+NGAS Command Plug-In, implementing a command to fill the mirroring_bookkeeping_table
 
-NOTES: By default only the last version found in the source cluster is synchronized
-       to the target cluster. To synchronize all existing versions specify all_versions=1.
-       In case of remote data-base mirroring it is necessary to enable data-base links
-       to the source/target data-bases in the local data-base. If the target data-base
-       is the local one is not neccesary to specify a target data-base link, (by default
-       the local data base is the target data base)
+NOTES
+------
+By default only the last version found in the source cluster is synchronized to the target cluster. To synchronize all
+existing versions specify all_versions=1. In case of remote data-base mirroring it is necessary to enable data-base
+links to the source/target data-bases in the local data-base. If the target data-base is the local one is not
+necessary to specify a target data-base link, (by default the local data base is the target data base)
 
-PARAMETERS:
-	-source_cluster	[mandatory] source cluster name
-	-target_cluster	[mandatory] target cluster name
-	-source_dbl	[optional] source archive data base link (remote data base mirroring)
-	-target_dbl	[optional] target archive data base link (remote data base mirroring)
-	-all_versions	[optional] (=1) mirror all missing versions of each file, default (=0)
-	-archive_cmd	[optional] custom archive command, default (=MIRRARCHIVE)
-	-retriev_cmd	[optional] custom retrieve command, default (=RETRIEVE)
+PARAMETERS
+----------
+* source_cluster [mandatory] source cluster name
+* target_cluster [mandatory] target cluster name
+* source_dbl [optional] source archive data base link (remote data base mirroring)
+* target_dbl [optional] target archive data base link (remote data base mirroring)
+* all_versions [optional] (=1) mirror all missing versions of each file, default (=0)
+* archive_cmd [optional] custom archive command, default (=MIRRARCHIVE)
+* retriev_cmd [optional] custom retrieve command, default (=RETRIEVE)
 
-EXAMPLES:
-	- Local data base mirroring with custom ARCHIVE command
-		http://ngas05.hq.eso.org:7778/MIRRTABLE?target_cluster=ngas05:7778&source_cluster=ngas02:7778&archive_cmd=QARCHIVE?
-
+EXAMPLES
+--------
+Local data base mirroring with custom ARCHIVE command
+    http://ngas05.hq.eso.org:7778/MIRRTABLE?target_cluster=ngas05:7778&source_cluster=ngas02:7778&archive_cmd=QARCHIVE?
 """
 
 import logging
@@ -63,151 +64,148 @@ from .alma.almaMirroringTargetNodeAssigner import TargetVolumeAssigner
 
 logger = logging.getLogger(__name__)
 
-def handleCmd(srvObj,
-              reqPropsObj,
-              httpRef):
+def handleCmd(ngams_server, request_properties, http_reference=None):
     """
     Handle Command MIRRTABLE to populate bookkeeping table in target cluster
-
-    INPUT:
-        srvObj:         ngamsServer, Reference to NG/AMS server class object
-
-        reqPropsObj:    ngamsReqProps, Request Property object to keep track
-                        of actions done during the request handling
-
-       httpRef:        ngamsHttpRequestHandler, Reference to the HTTP request
-                        handler object
-
-    RETURNS:        Void.
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :param request_properties: ngamsReqProps, Request properties to keep track of actions done during request handling
+    :param http_reference: HTTP reference
     """
+    # Get command parameters
+    target_cluster = ngams_server.getCfg().getVal("Mirroring[1].target_cluster")
+    if request_properties.hasHttpPar("target_cluster"):
+        target_cluster = request_properties.getHttpPar("target_cluster")
 
-    # Get command parameters.
-    target_cluster = srvObj.getCfg().getVal("Mirroring[1].target_cluster")
-    if (reqPropsObj.hasHttpPar("target_cluster")):
-        target_cluster = reqPropsObj.getHttpPar("target_cluster")
-    source_cluster = srvObj.getCfg().getVal("Mirroring[1].source_cluster")
-    if (reqPropsObj.hasHttpPar("source_cluster")):
-        source_cluster = reqPropsObj.getHttpPar("source_cluster")
-    source_dbl = "@" + srvObj.getCfg().getVal("Mirroring[1].source_dbl")
-    if (reqPropsObj.hasHttpPar("source_dbl")):
-        source_dbl = "@" + reqPropsObj.getHttpPar("source_dbl")
+    source_cluster = ngams_server.getCfg().getVal("Mirroring[1].source_cluster")
+    if request_properties.hasHttpPar("source_cluster"):
+        source_cluster = request_properties.getHttpPar("source_cluster")
+
+    source_dbl = "@" + ngams_server.getCfg().getVal("Mirroring[1].source_dbl")
+    if request_properties.hasHttpPar("source_dbl"):
+        source_dbl = "@" + request_properties.getHttpPar("source_dbl")
+
     target_dbl = ""
-    if (reqPropsObj.hasHttpPar("target_dbl")):
-        target_dbl = "@" + reqPropsObj.getHttpPar("target_dbl")
-    all_versions = srvObj.getCfg().getVal("Mirroring[1].all_versions")
-    if (reqPropsObj.hasHttpPar("all_versions")):
-        all_versions = int(reqPropsObj.getHttpPar("all_versions"))
+    if request_properties.hasHttpPar("target_dbl"):
+        target_dbl = "@" + request_properties.getHttpPar("target_dbl")
 
-    # what was the date of the last succesful mirroring iteration? We will only compare files
-    # from local and remote databases from that date (the start of the iteration, just to allow
-    # some error margin)
-    siteId = getCurrentSite(srvObj)
-    validArcs = ['EU', 'EA', 'NA', 'SCO', 'OSF']
-    if not (siteId in validArcs): raise Exception("Can not mirror, The table ngas_cfg_pars_properties does not contain an element 'siteId' with one of these values: " + str(validArcs))
+    all_versions = ngams_server.getCfg().getVal("Mirroring[1].all_versions")
+    if request_properties.hasHttpPar("all_versions"):
+        all_versions = int(request_properties.getHttpPar("all_versions"))
 
-    # we're overlapping mirroring iterations now. First check is to see if there are any spare threads
-    # for this iteration to use
-    numAvailableDownloadThreads = getNumAvailableDownloadThreads(srvObj)
-    if numAvailableDownloadThreads <= 0:
+    # What was the date of the last successful mirroring iteration? We will only compare files from local and remote
+    # databases from that date (the start of the iteration, just to allow some error margin)
+    site_id = get_current_site(ngams_server)
+    valid_arcs = ['EU', 'EA', 'NA', 'SCO', 'OSF']
+    if not (site_id in valid_arcs):
+        raise Exception("Cannot mirror, the table ngas_cfg_pars_properties does not contain an element 'siteId' " 
+                        "with one of these values: " + str(valid_arcs))
+
+    # We're overlapping mirroring iterations now. First check is to see if there are any spare threads for this
+    # iteration to use
+    num_available_download_threads = get_num_available_download_threads(ngams_server)
+    if num_available_download_threads <= 0:
         logger.info("All the available download threads are busy. Skipping this mirroring iteration.")
         return
-    logger.info("total num threads available for mirroring in the cluster: %d", numAvailableDownloadThreads)
+    logger.info("Total num threads available for mirroring in the cluster: %d", num_available_download_threads)
 
-    baselineDate = getMirroringBaselineDate(srvObj)
-    if baselineDate is None or baselineDate == "None":
-        startDate = "None"
+    baseline_date = get_mirroring_baseline_date(ngams_server)
+    if baseline_date is None or baseline_date == "None":
+        start_date = "None"
     else:
-        # work out the time window to compare files. We use the last succesful iteration and then subtract 100 for safety
-        startDate = findDateOfLastSuccessfulMirroringIteration(srvObj)
-        # however, if this is the first mirroring iteration of a new day then we perform a complete mirror
-        lastIteration = findDateOfLastMirroringIteration(srvObj)
-        if (lastIteration is None or lastIteration == "None" or lastIteration[8:10] != time.strftime('%d', time.localtime())):
+        # Work out the time window to compare files. We use the last succesful iteration and then subtract 100 for safety
+        start_date = find_date_of_last_successful_mirroring_iteration(ngams_server)
+        # However, if this is the first mirroring iteration of a new day then we perform a complete mirror
+        last_iteration = find_date_of_last_mirroring_iteration(ngams_server)
+        if last_iteration is None or last_iteration == "None" or last_iteration[8:10] != time.strftime('%d', time.localtime()):
             logger.info('performing a full mirroring')
-            startDate = "None"
-        # unless, of course, the baselineDate has been set. We never ever extend beyond that.
-        if startDate == "None" and baselineDate:
-            logger.info('using the baseline data from the config table: %s', baselineDate)
-            startDate = baselineDate + "T00:00:00:000"
-    rows_limit = getIterationFileLimit(srvObj)
+            start_date = "None"
+        # Unless, of course, the baseline_date has been set. We never ever extend beyond that.
+        if start_date == "None" and baseline_date:
+            logger.info('using the baseline data from the config table: %s', baseline_date)
+            start_date = baseline_date + "T00:00:00:000"
+    rows_limit = get_iteration_file_limit(ngams_server)
 
     # Get source cluster active nodes
-    source_active_nodes = get_cluster_active_nodes(source_dbl, source_cluster, srvObj)
+    source_active_nodes = get_cluster_active_nodes(source_dbl, source_cluster, ngams_server)
 
     if len(source_active_nodes) == 0:
-        logger.warning("there are no active source nodes. Skipping this iteration.")
+        logger.warning("There are no active source nodes. Skipping this iteration.")
     else:
         # Construct sub-query for source cluster
-        source_query = generate_source_files_query(srvObj, startDate, source_dbl, source_cluster, all_versions)
+        source_query = generate_source_files_query(ngams_server, start_date, source_dbl, source_cluster, all_versions)
         logger.debug("SQL sub-query to get source cluster files-hosts information: %s", source_query)
 
         # Construct sub-query for target cluster
-        target_query = generate_target_files_query(srvObj, startDate, target_cluster, all_versions)
+        target_query = generate_target_files_query(ngams_server, start_date, target_cluster, all_versions)
         logger.debug("SQL sub-query to get target cluster files-hosts information: %s", target_query)
 
         # Construct sub-query for  table
         diff_query = generate_diff_ngas_files_query(source_query, target_query)
         logger.debug("SQL sub-query to get diff between source and target files: %s", diff_query)
 
-        # Get iteration nmumber
-        iteration = get_mirroring_iteration(srvObj)
+        # Get iteration number
+        iteration = get_mirroring_iteration(ngams_server)
 
         # Populate book keeping table
         logger.debug("Populating ngas_mirroring_bookkeeping_table, source_cluster=%s , target_cluster=%s, all_versions=%s",
-             source_cluster + source_dbl, target_cluster + target_dbl, str(all_versions))
-        populate_mirroring_bookkeeping_table(diff_query, startDate, target_dbl, target_cluster, iteration, srvObj)
+                     source_cluster + source_dbl, target_cluster + target_dbl, str(all_versions))
+        populate_mirroring_bookkeeping_table(diff_query, start_date, target_dbl, target_cluster, iteration,
+                                             ngams_server)
 
-        # grab any toresume fetches for this iteration
-        reassign_broken_downloads(iteration, srvObj)
+        # Grab any TORESUME fetches for this iteration
+        reassign_broken_downloads(iteration, ngams_server)
 
-        # de-schedule any files which have been blocked from the SCO
-        deschedule_exclusions(iteration, 'EU', source_dbl, srvObj);
+        # De-schedule any files which have been blocked from the SCO
+        # FIXME: should this be hard coded as 'EU' ???
+        deschedule_exclusions(iteration, 'EU', source_dbl, ngams_server)
 
-        # limit the number of files that we will fetch in a single iteration
+        # Limit the number of files that we will fetch in a single iteration
         if rows_limit is not None and rows_limit != 'None':
-            limit_mirrored_files(srvObj, iteration, rows_limit)
+            limit_mirrored_files(ngams_server, iteration, rows_limit)
 
-        # remove the source nodes which do not have any files for mirroring during this iteration
-        working_source_nodes = remove_empty_source_nodes(iteration, source_active_nodes, target_cluster, srvObj)
+        # Remove the source nodes which do not have any files for mirroring during this iteration
+        working_source_nodes = remove_empty_source_nodes(iteration, source_active_nodes, target_cluster, ngams_server)
 
         # Assign book keeping table entries
         logger.info("Updating entries in ngas_mirroring_bookkeeping_table to assign target nodes")
-        totalFilesToMirror = assign_mirroring_bookkeeping_entries(iteration, working_source_nodes, target_cluster, srvObj)
+        total_files_to_mirror = assign_mirroring_bookkeeping_entries(iteration, working_source_nodes,
+                                                                     target_cluster, ngams_server)
 
-        logger.info("There are %d files are to be mirrored in iteration %d", totalFilesToMirror, iteration)
-        if totalFilesToMirror > 0:
-            t = threading.Thread(target=executeMirroring, args=(srvObj, iteration))
+        logger.info("There are %d files are to be mirrored in iteration %d", total_files_to_mirror, iteration)
+        if total_files_to_mirror > 0:
+            t = threading.Thread(target=execute_mirroring, args=(ngams_server, iteration))
             t.start()
     return
 
-def executeMirroring(srvObj, iteration):
+
+def execute_mirroring(ngams_server, iteration):
     logger.info('executeMirroring for iteration %d', iteration)
     try:
         rx_timeout = 30 * 60
-        if srvObj.getCfg().getVal("Mirroring[1].rx_timeout"):
-            rx_timeout = int(srvObj.getCfg().getVal("Mirroring[1].rx_timeout"))
+        if ngams_server.getCfg().getVal("Mirroring[1].rx_timeout"):
+            rx_timeout = int(ngams_server.getCfg().getVal("Mirroring[1].rx_timeout"))
 
         pars = {
             'mirror_cluster': 2,
             'iteration': str(iteration),
             'rx_timeout': rx_timeout,
-            'n_threads': getNumberOfSimultaneousFetchesPerServer(srvObj)
+            'n_threads': get_num_simultaneous_fetches_per_server(ngams_server)
         }
-        host, port = srvObj.get_self_endpoint()
+        host, port = ngams_server.get_self_endpoint()
         ngamsHttpUtils.httpGet(host, port, 'MIRREXEC', pars=pars, timeout=rx_timeout)
         # TODO look at the response code
-
     except Exception:
         logger.exception("Mirroring failed")
     finally:
-        failRemainingTransfers(srvObj, iteration);
+        fail_remaining_transfers(ngams_server, iteration)
         logger.info('executeMirroring for iteration %d complete', iteration)
 
-    # remove some of the older bookkeeping entries
-    clean_mirroring_bookkeeping_entries(srvObj)
+    # Remove some of the older bookkeeping entries
+    clean_mirroring_bookkeeping_entries(ngams_server)
 
-def getNumAvailableDownloadThreads(srvObj):
-    sql = "select numHosts * fetchesPerServer - currentFetches as availableFetches"
-    sql += " from"
+
+def get_num_available_download_threads(ngams_server):
+    sql = "select numHosts * fetchesPerServer - currentFetches as availableFetches from"
     sql += " ( select count(distinct(c.host_id)) as numHosts"
     sql += "   from ngas_cfg_pars p"
     sql += "     inner join ngas_hosts h on h.host_id = p.cfg_val"
@@ -221,431 +219,337 @@ def getNumAvailableDownloadThreads(srvObj):
     sql += "   from ngas_cfg_pars"
     sql += "   where cfg_par = 'numParallelFetches')"
 
-    res = srvObj.getDb().query2(sql)
-    numAvailable = int(res[0][0])
-    return numAvailable
-
-def failRemainingTransfers(srvObj, iteration):
-    logger.info('making sure there are no LOCKED or READY entries left for iteration %d', iteration)
-    sql = "update ngas_mirroring_bookkeeping set status = 'FAILURE' where status in ('LOCKED', 'READY') and iteration = {0}"
-    srvObj.getDb().query2(sql,args=(iteration,))
+    result = ngams_server.getDb().query2(sql)
+    num_available = int(result[0][0])
+    return num_available
 
 
-def reassign_broken_downloads(currentIteration, srvObj):
-    sql = "insert into ngas_mirroring_bookkeeping"
-    sql += " (file_id, file_version, file_size, disk_id, host_id, format, status,"
-    sql += " target_cluster, target_host, source_host, "
-    sql += " ingestion_date, ingestion_time, iteration, checksum, checksum_plugin, staging_file, attempt, source_ingestion_date)"
-    sql += " select file_id, file_version, file_size, disk_id, host_id, format, 'READY' as status,"
-    sql += " target_cluster, target_host, source_host,"
-    sql += " ingestion_date, ingestion_time, {0} as iteration, checksum, checksum_plugin, staging_file, attempt, source_ingestion_date"
-    sql += " from ngas_mirroring_bookkeeping "
-    sql += " where status = 'TORESUME'"
-    srvObj.getDb().query2(sql, args=(currentIteration,))
+def fail_remaining_transfers(ngams_server, iteration):
+    logger.info('Making sure there are no LOCKED or READY entries left for iteration %d', iteration)
+    sql = "update ngas_mirroring_bookkeeping set status = 'FAILURE' " \
+          "where status in ('LOCKED', 'READY') and iteration = {0}"
+    ngams_server.getDb().query2(sql, args=(iteration,))
 
-    # we've grabbed
-    sql = "update ngas_mirroring_bookkeeping"
-    sql += " set status = 'FAILURE',staging_file = null"
-    sql += " where status = 'TORESUME' and iteration < {0}"
-    srvObj.getDb().query2(sql, args=(currentIteration,))
 
-def clean_mirroring_bookkeeping_entries(srvObj):
-    # TBD parameterise the time period
-    logger.info('cleaning up mirroring bookkeeping table - removing entries older than 60 days')
+def reassign_broken_downloads(current_iteration, ngams_server):
+    sql = "insert into ngas_mirroring_bookkeeping " \
+          "(file_id, file_version, file_size, disk_id, host_id, " \
+          "format, status, target_cluster, target_host, source_host, " \
+          "ingestion_date, ingestion_time, iteration, checksum, checksum_plugin, " \
+          "staging_file, attempt, source_ingestion_date) " \
+          "select file_id, file_version, file_size, disk_id, host_id, " \
+          "format, 'READY' as status, target_cluster, target_host, source_host, " \
+          "ingestion_date, ingestion_time, {0} as iteration, checksum, checksum_plugin, " \
+          "staging_file, attempt, source_ingestion_date " \
+          "from ngas_mirroring_bookkeeping where status = 'TORESUME'"
+    ngams_server.getDb().query2(sql, args=(current_iteration,))
 
-    query = "delete from ngas_mirroring_bookkeeping where iteration < ("
-    query += "select max(iteration) from ("
-    query += "select iteration from ngas_mirroring_bookkeeping"
-    query += " group by iteration having min(status) = 'SUCCESS'"
-    query += " and substr(max(ingestion_date), 1, 10) < to_char(sysdate - 60, 'YYYY-MM-DD')))"
+    # We've grabbed
+    sql = "update ngas_mirroring_bookkeeping set status = 'FAILURE', staging_file = null " \
+          "where status = 'TORESUME' and iteration < {0}"
+    ngams_server.getDb().query2(sql, args=(current_iteration,))
 
-    srvObj.getDb().query2(query)
 
-def findDateOfLastMirroringIteration(srvObj):
-    query = "select min(ingestion_date)"
-    query += " from ngas_mirroring_bookkeeping"
-    query += " where iteration = ("
-    query += " select max(iteration) from ngas_mirroring_bookkeeping)"
+def clean_mirroring_bookkeeping_entries(ngams_server):
+    # TBD parameterize the time period
+    logger.info('Cleaning up mirroring bookkeeping table - removing entries older than 60 days')
+    sql = "delete from ngas_mirroring_bookkeeping where iteration < " \
+          "(select max(iteration) from " \
+          "(select iteration from ngas_mirroring_bookkeeping" \
+          " group by iteration having min(status) = 'SUCCESS'" \
+          " and substr(max(ingestion_date), 1, 10) < to_char(sysdate - 60, 'YYYY-MM-DD')))"
+    ngams_server.getDb().query2(sql)
 
-    # Execute query
-    res = srvObj.getDb().query2(query)
-    timestamp = str(res[0][0])
 
-    # Log info
-    logger.info("the date of the last mirroring iteration was %s", timestamp)
-
-    # Return void
+def find_date_of_last_mirroring_iteration(ngams_server):
+    sql = "select min(ingestion_date) from ngas_mirroring_bookkeeping " \
+          "where iteration = (select max(iteration) from ngas_mirroring_bookkeeping)"
+    result = ngams_server.getDb().query2(sql)
+    timestamp = str(result[0][0])
+    logger.info("The date of the last mirroring iteration was %s", timestamp)
     return timestamp
 
-def findDateOfLastSuccessfulMirroringIteration(srvObj):
-    query = "select min(ingestion_date)"
-    query += " from ngas_mirroring_bookkeeping"
-    query += " where iteration = ("
-    query += " select max(iteration) - 100 from ("
-    query += " select iteration from ngas_mirroring_bookkeeping"
-    query += " group by iteration having count(distinct(status)) = 1"
-    query += " and min(status) = 'SUCCESS'))"
 
-    # Execute query
-    res = srvObj.getDb().query2(query)
-    timestamp = str(res[0][0])
+def find_date_of_last_successful_mirroring_iteration(ngams_server):
+    sql = "select min(ingestion_date) from ngas_mirroring_bookkeeping " \
+          "where iteration = " \
+          "(select max(iteration) - 100 from " \
+          "(select iteration from ngas_mirroring_bookkeeping " \
+          " group by iteration having count(distinct(status)) = 1 and min(status) = 'SUCCESS'))"
 
-    # Log info
+    result = ngams_server.getDb().query2(sql)
+    timestamp = str(result[0][0])
     logger.info("The start of the sliding window is %s", timestamp)
-
-    # Return void
     return timestamp
 
-def getNumberOfSimultaneousFetchesPerServer(srvObj):
-    query = "select cfg_val"
-    query += " from ngas_cfg_pars"
-    query += " where cfg_par = 'numParallelFetches'"
 
-    res = srvObj.getDb().query2(query)
-    n_threads = str(res[0][0])
-    if n_threads == None or n_threads == "None":
-        n_threads = 5
-    return n_threads
+def get_num_simultaneous_fetches_per_server(ngams_server):
+    sql = "select cfg_val from ngas_cfg_pars where cfg_par = 'numParallelFetches'"
+    result = ngams_server.getDb().query2(sql)
+    num_threads = str(result[0][0])
+    if num_threads is None or num_threads == "None":
+        num_threads = 5
+    return num_threads
 
-def getMirroringBaselineDate(srvObj):
-    query = "select cfg_val"
-    query += " from ngas_cfg_pars"
-    query += " where cfg_par = 'baselineDate'"
 
-    res = srvObj.getDb().query2(query)
-    baselineDate = str(res[0][0])
+def get_mirroring_baseline_date(ngams_server):
+    sql = "select cfg_val from ngas_cfg_pars where cfg_par = 'baselineDate'"
+    result = ngams_server.getDb().query2(sql)
+    baseline_date = str(result[0][0])
+    logger.info("Mirroring baseline date is %s", baseline_date)
+    return baseline_date
 
-    logger.info("mirroring baseline date is %s", baselineDate)
-    return baselineDate
 
-def getIterationFileLimit(srvObj):
-    query = "select cfg_val"
-    query += " from ngas_cfg_pars"
-    query += " where cfg_par = 'iterationFileLimit'"
-
-    res = srvObj.getDb().query2(query)
-    limit = str(res[0][0])
+def get_iteration_file_limit(ngams_server):
+    sql = "select cfg_val from ngas_cfg_pars where cfg_par = 'iterationFileLimit'"
+    result = ngams_server.getDb().query2(sql)
+    limit = str(result[0][0])
     return limit
 
-def getCurrentSite(srvObj):
-    query = "select cfg_val"
-    query += " from ngas_cfg_pars"
-    query += " where cfg_par = 'siteId'"
 
-    res = srvObj.getDb().query2(query)
-    siteId = str(res[0][0])
-    if siteId == None or siteId == "None":
-        siteId = '?'
-    return siteId
+def get_current_site(ngams_server):
+    sql = "select cfg_val from ngas_cfg_pars where cfg_par = 'siteId'"
+    result = ngams_server.getDb().query2(sql)
+    site_id = str(result[0][0])
+    if site_id is None or site_id == "None":
+        site_id = '?'
+    return site_id
 
-def generate_source_files_query(srvObj,startDate, db_link,
-                                       cluster_name,
-                                       all_versions):
+
+def generate_source_files_query(ngams_server, start_date, db_link, cluster_name, all_versions):
     """
-    Specify an alias table that extends ngas_files
-    table including host_id/domain/srv_port information
-
-    INPUT:
-        db_link        string, Name for the data base link hosting the cluster
-    cluster_name    string, Name of the cluster involved in the operation
-    all_versions    int, Parameter to determine if all-versions mode is desired
-
-    RETURNS:
-        query       string, Sub-Query to be aliased in a whole query
+    Specify an alias table that extends ngas_files table including host_id/domain/srv_port information
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :param start_date: Start date
+    :param db_link: string, Name for the data base link hosting the cluster
+    :param cluster_name: string, Name of the cluster involved in the operation
+    :param all_versions: int, Parameter to determine if all-versions mode is desired
+    :return: string, Sub-Query to be aliased in a whole query
     """
-
     # Query create table statement (common)
-    query = "(select nf.file_id file_id, nf.file_version file_version, "
-    query += "min(ingestion_date) ingestion_date, "
-    query += "substr(min(nf.disk_id || nh.host_id || nh.srv_port),1,length(min(nd.disk_id))) disk_id, "
-    query += "substr(min(nf.disk_id || nh.host_id || nh.srv_port),1+length(min(nd.disk_id)),length(min(nh.host_id))) host_id, "
-    query += "substr(min(nf.disk_id || nh.host_id || nh.srv_port),1+length(min(nd.disk_id))+length(min(nh.host_id)),length(min(nh.srv_port))) srv_port, "
-    query += "min(nf.format) format, min(nf.file_size) file_size, min(nf.checksum) checksum, min(nf.checksum_plugin) checksum_plugin, min(nh.domain) domain "
-    query += "from "
+    sql = "(select nf.file_id file_id, nf.file_version file_version, "
+    sql += "min(ingestion_date) ingestion_date, "
+    sql += "substr(min(nf.disk_id || nh.host_id || nh.srv_port),1,length(min(nd.disk_id))) disk_id, "
+    sql += "substr(min(nf.disk_id || nh.host_id || nh.srv_port),1+length(min(nd.disk_id)),length(min(nh.host_id))) host_id, "
+    sql += "substr(min(nf.disk_id || nh.host_id || nh.srv_port),1+length(min(nd.disk_id))+length(min(nh.host_id)),length(min(nh.srv_port))) srv_port, "
+    sql += "min(nf.format) format, min(nf.file_size) file_size, min(nf.checksum) checksum, min(nf.checksum_plugin) checksum_plugin, min(nh.domain) domain "
+    sql += "from "
     # Depending on all_versions parameter we select only last version or not
     if all_versions:
-        query += "ngas_files" + db_link + " nf inner join ngas_disks" + db_link + " nd on nd.disk_id = nf.disk_id "
-        query += "inner join ngas_hosts" + db_link + " nh on nh.host_id = nd.host_id "
+        sql += "ngas_files" + db_link + " nf inner join ngas_disks" + db_link + " nd on nd.disk_id = nf.disk_id "
+        sql += "inner join ngas_hosts" + db_link + " nh on nh.host_id = nd.host_id "
     else:
-        query += "(select file_id, max(file_version) file_version from ngas_files" + db_link + " group by file_id) nflv "
-        query += "inner join ngas_files" + db_link + " nf on nf.file_id = nflv.file_id and nf.file_version = nflv.file_version "
-        query += "inner join ngas_disks" + db_link + " nd on nd.disk_id = nf.disk_id "
-        query += "inner join ngas_hosts" + db_link + " nh on nh.host_id = nd.host_id "
-    # for clarity,I used to insert all entries and then remove them according to the exclusion rules in a second step.
+        sql += "(select file_id, max(file_version) file_version from ngas_files" + db_link + " group by file_id) nflv "
+        sql += "inner join ngas_files" + db_link + " nf on nf.file_id = nflv.file_id and nf.file_version = nflv.file_version "
+        sql += "inner join ngas_disks" + db_link + " nd on nd.disk_id = nf.disk_id "
+        sql += "inner join ngas_hosts" + db_link + " nh on nh.host_id = nd.host_id "
+    # For clarity, I used to insert all entries and then remove them according to the exclusion rules in a second step.
     # The problem with that (in the dev environment) is the performance. It brings over way more rows from the source
     # DB than is required.
-    query += " left join alma_mirroring_exclusions c "
-    # replace(ingestion_date, ':60.000', ':59.999'):
-    # some "timestamps" (stored as varchar2 in Oracle) have 60 as the seconds value due to an
-    # earlier NGAS bug. We can't convert that to an Oracle timestamp so have to hack it.
-    query += " on file_id like c.file_pattern and to_timestamp(replace(ingestion_date, ':60.000', ':59.999'), 'YYYY-MM-DD\"T\"HH24:MI:SS.FF') between c.ingestion_start and c.ingestion_end and arc = 'HERE'"
-    query += "where "
-    # ignore certain mime types
-    query += "nf.format not in ('application/octet-stream', 'text/log-file', 'unknown') and "
-    # no longer ignore files where the file_status is not 0. Always replicate to the ARCs.
-    colname = 'file_ignore' if srvObj.getCfg().getDbUseFileIgnore() else 'ignore'
-    query += "nf.%s=0 and " % (colname)
+    sql += " left join alma_mirroring_exclusions c "
+    # Replace(ingestion_date, ':60.000', ':59.999'):
+    # some "timestamps" (stored as varchar2 in Oracle) have 60 as the seconds value due to an earlier NGAS bug.
+    # We can't convert that to an Oracle timestamp so have to hack it.
+    sql += " on file_id like c.file_pattern and to_timestamp(replace(ingestion_date, ':60.000', ':59.999'), 'YYYY-MM-DD\"T\"HH24:MI:SS.FF') between c.ingestion_start and c.ingestion_end and arc = 'HERE'"
+    sql += "where "
+    # Ignore certain mime types
+    sql += "nf.format not in ('application/octet-stream', 'text/log-file', 'unknown') and "
+    # No longer ignore files where the file_status is not 0. Always replicate to the ARCs.
+    column_name = 'file_ignore' if ngams_server.getCfg().getDbUseFileIgnore() else 'ignore'
+    sql += "nf.%s=0 and " % column_name
     # Query join conditions to reach host_id (common) and check cluster name
-    query += "nh.cluster_name='" + cluster_name + "' "
-    if startDate is not None and startDate != "None":
-        query += " and ingestion_date > {0} "
-    query += " group by nf.file_id,nf.file_version"
-    query += " having (max(rule_type) is null or max(rule_type) <> 'EXCLUDE')"
-    query += ")"
+    sql += "nh.cluster_name='" + cluster_name + "' "
+    if start_date is not None and start_date != "None":
+        sql += " and ingestion_date > {0} "
+    sql += " group by nf.file_id,nf.file_version"
+    sql += " having (max(rule_type) is null or max(rule_type) <> 'EXCLUDE')"
+    sql += ")"
+    return sql
 
-    # Return query
-    return query
 
-def generate_target_files_query(srvObj, startDate,
-                                cluster_name,
-                                all_versions):
+def generate_target_files_query(ngams_server, start_date, cluster_name, all_versions):
     """
-    Specify an alias table that extends ngas_files
-    table including host_id/domain/srv_port information
-
-    INPUT:
-        db_link        string, Name for the data base link hosting the cluster
-    cluster_name    string, Name of the cluster involved in the operation
-    all_versions    int, Parameter to determine if all-versions mode is desired
-
-    RETURNS:
-        query       string, Sub-Query to be aliased in a whole query
+    Specify an alias table that extends ngas_files table including host_id/domain/srv_port information
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :param cluster_name: string, Name of the cluster involved in the operation
+    :param all_versions: int, Parameter to determine if all-versions mode is desired
+    :return: string, Sub-Query to be aliased in a whole query
     """
-
     # Query create table statement (common)
-    query = "(select nf.file_id file_id, nf.file_version file_version "
-    query += "from "
+    sql = "(select nf.file_id file_id, nf.file_version file_version "
+    sql += "from "
     # Depending on all_versions parameter we select only last version or not
     if all_versions:
-        query += "ngas_files nf inner join ngas_disks nd on nd.disk_id = nf.disk_id "
-        query += "inner join ngas_hosts nh on nh.host_id = nd.last_host_id "
+        sql += "ngas_files nf inner join ngas_disks nd on nd.disk_id = nf.disk_id "
+        sql += "inner join ngas_hosts nh on nh.host_id = nd.last_host_id "
     else:
-        query += "(select file_id, max(file_version) file_version from ngas_files group by file_id) nflv "
-        query += "inner join ngas_files nf on nf.file_id = nflv.file_id and nf.file_version = nflv.file_version "
-        query += "inner join ngas_disks nd on nd.disk_id = nf.disk_id "
-        query += "inner join ngas_hosts nh on nh.host_id = nd.last_host_id "
-    query += "where "
+        sql += "(select file_id, max(file_version) file_version from ngas_files group by file_id) nflv "
+        sql += "inner join ngas_files nf on nf.file_id = nflv.file_id and nf.file_version = nflv.file_version "
+        sql += "inner join ngas_disks nd on nd.disk_id = nf.disk_id "
+        sql += "inner join ngas_hosts nh on nh.host_id = nd.last_host_id "
+    sql += "where "
     # ICT-1988 - cannot take file_status into consideration
     # query += "nf.ignore=0 and nf.file_status=0 and "
-    colname = 'file_ignore' if srvObj.getCfg().getDbUseFileIgnore() else 'ignore'
-    query += "nf.%s=0 and " % (colname)
+    column_name = 'file_ignore' if ngams_server.getCfg().getDbUseFileIgnore() else 'ignore'
+    sql += "nf.%s=0 and " % column_name
     # Query join conditions to reach host_id (common) and check cluster name
-    query += "nh.cluster_name='" + cluster_name + "' "
-    if startDate is not None and startDate != "None":
-        query += "and ingestion_date > {0} "
-    query += "group by nf.file_id,nf.file_version"
-    # these are the files that are currently downloading. We include them in the union so
-    # that they wil not be re-considered for mirroring
-    query += " union all"
-    # query += " select nf.file_id file_id, nf.file_version file_version from"
-    # query += " (select file_id, file_version, target_host from ngas_mirroring_bookkeeping "
-    # query += " where status in ('READY', 'TORESUME', 'FETCHING')) nf"
-    # query += " inner join ngas_hosts h on replace(h.host_id, ':', '.' || domain || ':') = nf.target_host"
-    # query += " group by nf.file_id, nf.file_version))"
-    query += " select file_id, file_version from ngas_mirroring_bookkeeping "
-    query += " where status in ('READY', 'TORESUME', 'FETCHING')"
-    query += " group by file_id, file_version)"
-
-    # Return query
-    return query
+    sql += "nh.cluster_name='" + cluster_name + "' "
+    if start_date is not None and start_date != "None":
+        sql += "and ingestion_date > {0} "
+    sql += "group by nf.file_id,nf.file_version"
+    # These are the files that are currently downloading. We include them in the union so that they wil not be
+    # re-considered for mirroring
+    sql += " union all"
+    # sql += " select nf.file_id file_id, nf.file_version file_version from"
+    # sql += " (select file_id, file_version, target_host from ngas_mirroring_bookkeeping "
+    # sql += " where status in ('READY', 'TORESUME', 'FETCHING')) nf"
+    # sql += " inner join ngas_hosts h on replace(h.host_id, ':', '.' || domain || ':') = nf.target_host"
+    # sql += " group by nf.file_id, nf.file_version))"
+    sql += " select file_id, file_version from ngas_mirroring_bookkeeping "
+    sql += " where status in ('READY', 'TORESUME', 'FETCHING')"
+    sql += " group by file_id, file_version)"
+    return sql
 
 
-def generate_diff_ngas_files_query(source_ext_ngas_files_query,
-                                   target_ext_ngas_files_query):
+def generate_diff_ngas_files_query(source_ext_ngas_files_query, target_ext_ngas_files_query):
     """
-    Specify an alias table to handle the result
-    of the left join (diff) query between source
-    and target extended ngas files sub-queries
-
-    INPUT:
-        source_ext_ngas_files_query    string, Sub-Query defining ngas_files information in source cluster
-        target_ext_ngas_files_query    string, Sub-Query defining ngas_files information in target cluster
-
-    RETURNS:
-        query               string, Sub-Query to be aliased in a whole query
+    Specify an alias table to handle the result of the left join (diff) query between source and target extended NGAS
+    files sub-queries
+    :param source_ext_ngas_files_query: string, Sub-Query defining ngas_files information in source cluster
+    :param target_ext_ngas_files_query: string, Sub-Query defining ngas_files information in target cluster
+    :return" string, Sub-Query to be aliased in a whole query
     """
-
     # Query create table statement (common)
-    query = "(select source.file_id, source.file_version, source.disk_id,"
-    query += " source.format, source.file_size, source.checksum, source.checksum_plugin,"
-    query += " source.host_id, source.domain, source.srv_port,"
-    # replace: some "timestamps" (stored as varchar2 in Oracle) have 60 as the seconds value due to an
-    # earlier NGAS bug. We can't convert that to an Oracle timestamp so have to hack it.
-    query += " to_timestamp(replace(source.ingestion_date, ':60.000', ':59.999'), 'YYYY-MM-DD\"T\"HH24:MI:SS:FF') as ingestion_date"
-    query += " from "
-
+    sql = "(select source.file_id, source.file_version, source.disk_id,"
+    sql += " source.format, source.file_size, source.checksum, source.checksum_plugin,"
+    sql += " source.host_id, source.domain, source.srv_port,"
+    # Replace: some "timestamps" (stored as varchar2 in Oracle) have 60 as the seconds value due to an earlier NGAS bug.
+    # We can't convert that to an Oracle timestamp so have to hack it.
+    sql += " to_timestamp(replace(source.ingestion_date, ':60.000', ':59.999'), 'YYYY-MM-DD\"T\"HH24:MI:SS:FF') as ingestion_date"
+    sql += " from "
     # Query left join condition
-    query += source_ext_ngas_files_query + " source left join " + target_ext_ngas_files_query + " target on "
-    query += "target.file_id = source.file_id and target.file_version = source.file_version "
+    sql += source_ext_ngas_files_query + " source left join " + target_ext_ngas_files_query + " target on "
+    sql += "target.file_id = source.file_id and target.file_version = source.file_version "
     # Get no-matched records
-    query += "where target.file_id is null)"
-
-    # Log info
-    logger.debug("SQL sub-query to generate extended ngas_files table: %s", query)
-
-    # Return query
-    return query
+    sql += "where target.file_id is null)"
+    logger.debug("SQL sub-query to generate extended ngas_files table: %s", sql)
+    return sql
 
 
-def get_mirroring_iteration(srvObj):
-
+def get_mirroring_iteration(ngams_server):
     """
     Get iteration number for next mirroring loop
     """
-
-    # Construct query
-    query = "select max(iteration)+1 from ngas_mirroring_bookkeeping"
-
-    # Execute query
-    res = srvObj.getDb().query2(query)
-    iteration = res[0][0] or 1
-
-    logger.info("next mirroring iteraion: %d", iteration)
-
-    # Return void
+    sql = "select max(iteration)+1 from ngas_mirroring_bookkeeping"
+    result = ngams_server.getDb().query2(sql)
+    iteration = result[0][0] or 1
+    logger.info("Next mirroring iteration: %d", iteration)
     return iteration
 
 
-def populate_mirroring_bookkeeping_table(diff_ngas_files_query,
-                                         startDate,
-                                         dbLink,
-                                         cluster_name,
-                                         iteration,
-                                         srvObj):
+def populate_mirroring_bookkeeping_table(diff_ngas_files_query, start_date, db_link, cluster_name,
+                                         iteration, ngams_server):
     """
-    Populate mirroring book keeping table with the
-    diff between the source and target tables.
-
-    INPUT:
-        diff_ngas_files_query    string, Sub-Query defining the diff between the ngas_files
-                    in the source and target clusters
-        dbLink            string, Name for the data base link hosting the target cluster
-    cluster_name        string, Name of the target cluster
-        iteration        string, Iteration number for next mirroring loop
-    srvObj            ngamsServer, Reference to NG/AMS server class object
-
-    RETURNS:        Void.
+    Populate mirroring book keeping table with the difference between the source and target tables.
+    :param diff_ngas_files_query: string, Sub-Query defining the diff between ngas_files in source and target clusters
+    :param start_date: Start date
+    :param db_link: string, Name for the data base link hosting the target cluster
+    :param cluster_name: string, Name of the target cluster
+    :param iteration: string, Iteration number for next mirroring loop
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
     """
-
-    ## First dump information from diff_ngas_files into book keeping table
-
+    # First dump information from diff_ngas_files into book keeping table
     # Insert query statement
-    query = "insert into ngas_mirroring_bookkeeping" + dbLink + " "
+    sql = "insert into ngas_mirroring_bookkeeping" + db_link + " "
     # Fields to be filled
-    query += "(file_id, file_version, disk_id, host_id, "
-    query += "file_size, format, status, target_cluster, "
-    query += "source_host, ingestion_date, "
-    query += "iteration, checksum, checksum_plugin, source_ingestion_date)"
-    query += "select "
+    sql += "(file_id, file_version, disk_id, host_id, "
+    sql += "file_size, format, status, target_cluster, "
+    sql += "source_host, ingestion_date, "
+    sql += "iteration, checksum, checksum_plugin, source_ingestion_date)"
+    sql += "select "
     # file_id: Direct from diff_ngas_files table
-    query += "d.file_id, "
+    sql += "d.file_id, "
     # file_version: Direct from diff_ngas_files table
-    query += "d.file_version, "
+    sql += "d.file_version, "
     # disk_id: Direct from diff_ngas_files table
-    query += "d.disk_id, "
+    sql += "d.disk_id, "
     # host_id: Direct from diff_ngas_files table
-    query += "d.host_id, "
+    sql += "d.host_id, "
     # file_size: Direct from diff_ngas_files table
-    query += "d.file_size, "
+    sql += "d.file_size, "
     # format: Direct from diff_ngas_files table
-    query += "d.format, "
+    sql += "d.format, "
     # status: Must be filled with 0 in case of no-ready entry
-    query += "'LOCKED',"
-    # target_host: We can temporary use the name of the target cluster
-    #              rather than the target host to lock the table entry
-    query += "'" + cluster_name + "', "
+    sql += "'LOCKED',"
+    # target_host: We can temporary use the name of the target cluster rather than the target host to lock table entry
+    sql += "'" + cluster_name + "', "
     # source_host: We concatenate host_id (without port)
-    query += "substr(d.host_id,0,instr(d.host_id || ':',':')-1) || '.' || "
-    #              With domain name and port number
-    query += "d.domain || ':' || d.srv_port, "
+    sql += "substr(d.host_id,0,instr(d.host_id || ':',':')-1) || '.' || "
+    # With domain name and port number
+    sql += "d.domain || ':' || d.srv_port, "
     # ingestion_date: We have to assign it a default value because it is part of the primary key
-    query += "{1}, "
+    sql += "{1}, "
     # iteration: In order to distinguish from different runs
-    query += "{2}, "
-    # the checksum from the source node
-    query += "d.checksum, d.checksum_plugin, d.ingestion_date"
+    sql += "{2}, "
+    # The checksum from the source node
+    sql += "d.checksum, d.checksum_plugin, d.ingestion_date"
     # All this info comes from the diff table
-    query += " from " + diff_ngas_files_query + " d"
-    #if rows_limit is not None and rows_limit != "None":
+    sql += " from " + diff_ngas_files_query + " d"
+    # if rows_limit is not None and rows_limit != "None":
     #    query += " where rownum <= " + str(rows_limit)
 
     # args are startDate, ingestionTime and iteration
-    args = (startDate, toiso8601(fmt=FMT_DATETIME_NOMSEC) + ":000", iteration)
-    srvObj.getDb().query2(query, args=args)
-
-    # Return void
+    args = (start_date, toiso8601(fmt=FMT_DATETIME_NOMSEC) + ":000", iteration)
+    ngams_server.getDb().query2(sql, args=args)
     return
 
 
-def get_cluster_active_nodes(db_link,
-                             cluster_name,
-                             srvObj):
+def get_cluster_active_nodes(db_link, cluster_name, ngams_server):
     """
     Return active nodes in a NG/AMS cluster
-
-    INPUT:
-        dbLink        string, Name for the data base link of the cluster
-        cluster_name    string, Name of the cluster to check
-        srvObj         ngamsServer, Reference to NG/AMS server class object
-
-    RETURNS:
-        active_nodes    list[strings], List of the active nodes in the cluster
+    :param db_link: string, Name for the data base link of the cluster
+    :param cluster_name: string, Name of the cluster to check
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :return: list[strings], List of the active nodes in the cluster
     """
-
     # Construct query
-    # TODO but only if there is a disk available....
-    query = "select substr(host_id,0,instr(host_id || ':',':')-1) || '.' || domain || ':' || srv_port "
-    query += "from ngas_hosts" + db_link + " where "
-    query += "cluster_name='" + cluster_name + "' and srv_state='ONLINE'"
-
-    # Execute query
-    active_nodes = [x[0] for x in srvObj.getDb().query2(query)]
-
-    # Log info
+    # TODO: but only if there is a disk available....
+    sql = "select substr(host_id, 0, instr(host_id || ':',':')-1) || '.' || domain || ':' || srv_port " \
+          "from ngas_hosts" + db_link + \
+          " where cluster_name = '" + cluster_name + "' and srv_state = 'ONLINE'"
+    active_nodes = [x[0] for x in ngams_server.getDb().query2(sql)]
     logger.info("Active nodes found in cluster %s: %s", cluster_name + db_link, str(active_nodes))
-
-    # Return active nodes list
     return active_nodes
 
 
-def remove_empty_source_nodes(iteration,
-                              source_active_nodes,
-                              cluster_name,
-                              srv_obj):
+def remove_empty_source_nodes(iteration, source_active_nodes, cluster_name, ngams_server):
     """
     Remove source active nodes that don't contain any file to mirror
-
-    INPUT:
-        source_active_nodes    string, List of active nodes in the source cluster
-        cluster_name        string, Name of the target_cluster
-        srvObj              ngamsServer, Reference to NG/AMS server class object
-
-    RETURNS:
-        source_nodes    list[strings], List of the active source nodes
+    :param iteration: Iteration
+    :param source_active_nodes: string, List of active nodes in the source cluster
+    :param cluster_name: string, Name of the target_cluster
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :return: list[strings], List of the active source nodes
     """
-
-    # Construct query
-    query = "select source_host from ngas_mirroring_bookkeeping where target_cluster={0} "
-    query += " and (status='LOCKED' or status = 'READY') and iteration = {1} group by source_host"
-
-    source_nodes_object = srv_obj.getDb().query2(query, args=(cluster_name, iteration))
+    sql = "select source_host from ngas_mirroring_bookkeeping " \
+          "where target_cluster = {0}  and (status='LOCKED' or status = 'READY') and iteration = {1} " \
+          "group by source_host"
+    source_nodes_object = ngams_server.getDb().query2(sql, args=(cluster_name, iteration))
 
     # Re-dimension query results array
     source_nodes = [x[0] for x in source_nodes_object]
-    logger.info("source nodes: %r", source_nodes)
+    logger.info("Source nodes: %r", source_nodes)
 
     # Compute the intersection of both lists
     working_nodes = []
     for node in source_active_nodes:
         if source_nodes.count(node) > 0:
             working_nodes.append(node)
-    logger.info("active source nodes: %r", working_nodes)
-
-    # Return working nodes list
+    logger.info("Active source nodes: %r", working_nodes)
     return working_nodes
 
 
-def deschedule_exclusions(iteration, arc, db_link, srv_obj):
+def deschedule_exclusions(iteration, arc, db_link, ngams_server):
     sql = "delete from ngas_mirroring_bookkeeping b where b.rowid in ("
     sql += "select min(f.rowid) from ngas_mirroring_bookkeeping f"
     sql += " left join alma_mirroring_exclusions" + db_link + " c on f.file_id like c.file_pattern"
@@ -653,69 +557,64 @@ def deschedule_exclusions(iteration, arc, db_link, srv_obj):
     sql += " and arc = {0} and iteration = {1}"
     sql += " group by f.file_id, f.file_version having max(rule_type) = 'EXCLUDE')"
 
-    logger.info('removing SCO exclusions')
+    logger.info('Removing SCO exclusions')
     try:
-        srv_obj.getDb().query2(sql, args=(arc, iteration))
+        ngams_server.getDb().query2(sql, args=(arc, iteration))
     except Exception:
-        # this clause should never be reached
+        # This clause should never be reached
         logger.exception("Fetch failed in an unexpected way")
 
 
-def limit_mirrored_files(srv_obj, iteration, file_limit):
-    # this is just used in development. I recommend not to use it in production, otherwise
-    # we risk losing partially downloaded file.
-    logger.info('limiting the number of files to fetch to %s', file_limit)
+def limit_mirrored_files(ngams_server, iteration, file_limit):
+    # This is just used in development. I recommend not to use it in production, otherwise we risk losing partially
+    # downloaded file.
+    logger.info('Limiting the number of files to fetch to %s', file_limit)
     sql = "delete from ngas_mirroring_bookkeeping where rowid in ("
     sql += "select myrowid from ("
     sql += "select rowid as myrowid, rownum as myrownum from ngas_mirroring_bookkeeping where iteration = {0}"
-    # prefer files which are already downloading - otherwise we risk losing the data that has already been downloaded
+    # Prefer files which are already downloading - otherwise we risk losing the data that has already been downloaded
     sql += " order by staging_file"
     sql += ") where myrownum > {1})"
 
-    srv_obj.getDb().query2(sql, args=(iteration, file_limit))
+    ngams_server.getDb().query2(sql, args=(iteration, file_limit))
 
 
-def get_files_to_mirror_from_node(iteration, source_node, srv_obj):
+def get_files_to_mirror_from_node(iteration, source_node, ngams_server):
     # type: (object, object, object) -> object
     # Construct query, for every update the nodes left are n_nodes-i
-    query = "select file_id, file_version, file_size"
-    query += " from ngas_mirroring_bookkeeping"
-    query += " where iteration = {0}"
-    query += " and SOURCE_HOST = {1}"
-    query += " and status = 'LOCKED'"
-    logger.info("SQL to obtain all files to be mirrored from host %s: %s", source_node, query)
-    return srv_obj.getDb().query2(query, args=(iteration, source_node))
+    sql = "select file_id, file_version, file_size " \
+          "from ngas_mirroring_bookkeeping " \
+          "where iteration = {0} and SOURCE_HOST = {1} and status = 'LOCKED'"
+    logger.info("SQL to obtain all files to be mirrored from host %s: %s", source_node, sql)
+    return ngams_server.getDb().query2(sql, args=(iteration, source_node))
 
 
-def get_target_node_disks(srv_obj, cluster_name):
-    """I know this algorithm is still vague and can easily fail. We can get into race conditions, or
-    an operator can manually ingest a large fie and mess up the space calculations. That's fine. We'll
-    recover from such situations later. At this point we just don't want to assign files to disks where
-    we know there is clearly not enough space to store them"""
-
+def get_target_node_disks(ngams_server, cluster_name):
+    """
+    I know this algorithm is still vague and can easily fail. We can get into race conditions, or an operator can
+    manually ingest a large fie and mess up the space calculations. That's fine. We'll recover from such situations
+    later. At this point we just don't want to assign files to disks where we know there is clearly not enough space
+    to store them
+    """
     # Construct query, for every update the nodes left are n_nodes-i
-    query = "select replace(h.host_id, ':', '.' || h.domain || ':'), h.domain, d.mount_point, d.available_mb * (1024 * 1024)"
-    query += " from ngas_hosts h"
-    query += "   inner join ngas_disks d"
-    query += "     on d.LAST_HOST_ID = h.host_id"
-    query += " where h.cluster_name = {0}"
-    query += " and h.srv_archive = 1 and srv_state = 'ONLINE'"
-    query += " and d.mounted = 1 and d.completed = 0"
-    query += " order by h.host_id, d.mount_point"
-    logger.info("SQL to obtain all target disks %s", query)
-    rs = srv_obj.getDb().query2(query, args=(cluster_name,))
+    sql = "select replace(h.host_id, ':', '.' || h.domain || ':'), h.domain, d.mount_point, d.available_mb * (1024 * 1024)"
+    sql += " from ngas_hosts h"
+    sql += "   inner join ngas_disks d"
+    sql += "     on d.LAST_HOST_ID = h.host_id"
+    sql += " where h.cluster_name = {0}"
+    sql += " and h.srv_archive = 1 and srv_state = 'ONLINE'"
+    sql += " and d.mounted = 1 and d.completed = 0"
+    sql += " order by h.host_id, d.mount_point"
+    logger.info("SQL to obtain all target disks %s", sql)
+    result = ngams_server.getDb().query2(sql, args=(cluster_name,))
     disks = {}
-    for row in rs:
+    for row in result:
         host_id = row[0]
 
-        # TODO: this is an ugly fix for an ugly situation in which the
-        #       host_id already contains the domain name (but the SQL code
-        #       assumes that it doesn't).
-        #       The hostId of a server is simply hostname:port. Depending on
-        #       how the machine is configured, the hostname will be a fully-
-        #       qualified hostname or not, and therefore the host_id
-        #       returned by the query will contain the domain twice.
-        #       Let's solve that
+        # TODO: this is an ugly fix for an ugly situation in which the host_id already contains the domain name
+        #  (but the SQL code assumes that it doesn't). The hostId of a server is simply hostname:port. Depending on
+        #  how the machine is configured, the hostname will be a fully- qualified hostname or not, and therefore the
+        #  host_id returned by the query will contain the domain twice. Let's solve that
         domain = row[1]
         double_domain_start = host_id.find(domain + "." + domain)
         if double_domain_start != -1:
@@ -728,18 +627,20 @@ def get_target_node_disks(srv_obj, cluster_name):
     return disks
 
 
-def get_target_node_disks_scheduled(srv_obj):
+def get_target_node_disks_scheduled(ngams_server):
     # type: (object) -> object
     # Construct query, for every update the nodes left are n_nodes-i
-    query = "select target_host, substr(staging_file, 0, instr(staging_file, '/', 1, 3) - 1), sum(file_size), count(file_size)"
-    query += " from ngas_mirroring_bookkeeping"
-    query += " where target_host is not null"
-    query += " and status in ('READY', 'LOCKED', 'FETCHING', 'TORESUME')"
-    query += " group by target_host, substr(staging_file, 0, instr(staging_file, '/', 1, 3) - 1)"
-    logger.info("SQL to obtain all target disks %s", query)
-    rs = srv_obj.getDb().query2(query)
+    sql = "select target_host, substr(staging_file, 0, instr(staging_file, '/', 1, 3) - 1), sum(file_size), count(file_size)"
+    sql += " from ngas_mirroring_bookkeeping"
+    sql += " where target_host is not null"
+    sql += " and status in ('READY', 'LOCKED', 'FETCHING', 'TORESUME')"
+    sql += " group by target_host, substr(staging_file, 0, instr(staging_file, '/', 1, 3) - 1)"
+
+    logger.info("SQL to obtain all target disks %s", sql)
+    result = ngams_server.getDb().query2(sql)
+
     disks = {}
-    for row in rs:
+    for row in result:
         host_id = row[0]
         mount_point = row[1]
         used_bytes = row[2]
@@ -750,85 +651,71 @@ def get_target_node_disks_scheduled(srv_obj):
 
 
 def assign_files_to_target_nodes(files, assigner, volumes_to_files):
-    logger.info('assigning %d files to host volums', len(files))
+    logger.info('Assigning %d files to host volumes', len(files))
     for (index, next_file_to_be_mirrored) in enumerate(files):
         target_host, target_volume = assigner.get_next_target_with_space_for(next_file_to_be_mirrored[2])
-        logger.info("%s / %s: assigning %s to host %s, volume %s", index, len(files), next_file_to_be_mirrored[0], target_host, target_volume)
+        logger.info("%s / %s: assigning %s to host %s, volume %s", index, len(files), next_file_to_be_mirrored[0],
+                    target_host, target_volume)
         volumes_to_files.setdefault((target_host, target_volume), []).append(next_file_to_be_mirrored)
 
 
-def assign_mirroring_bookkeeping_entries(iteration,
-                                         source_cluster_active_nodes,
-                                         cluster_name,
-                                         srv_obj):
+def assign_mirroring_bookkeeping_entries(iteration, source_cluster_active_nodes, cluster_name, ngams_server):
     """
-    Update target_cluster field in the book keeping
-    table in order to assign entries to each node.
+    Update target_cluster field in the book keeping table in order to assign entries to each node.
 
-    The entries are assigned to target cluster nodes
-    making sure that the file-size distribution is
-    balanced. To do it so the entries to be assigned
-    are first file-size sorted and then the 1st entry
-    is assigned to the first node, the 2nd entry to
-    the 2nd node and so on until all the nodes have
-    been assigned one entry and then it starts again.
+    The entries are assigned to target cluster nodes making sure that the file-size distribution is balanced. To do it
+    so the entries to be assigned are first file-size sorted and then the 1st entry is assigned to the first node, the
+    2nd entry to the 2nd node and so on until all the nodes have been assigned one entry and then it starts again.
 
-    At the end all the nodes should have been assigned
-    the same number of files, the same total load in Mb
-    and the same distribution of files in terms of file size.
-
-    INPUT:
-        target_cluster_active_nodes    list[strings], List of the active nodes in the target cluster
-        target_cluster_source_nodes     list[strings], List of the active nodes in the source cluster
-        db_link                string, Name for the data base link hosting the target cluster
-        cluster_name            string, Name of the target cluster
-        srvObj                ngamsServer, Reference to NG/AMS server class object
-    RETURNS:            Void.
+    At the end all the nodes should have been assigned the same number of files, the same total load in MB and the
+    same distribution of files in terms of file size.
+    :param iteration: Iteration
+    :param source_cluster_active_nodes: list[strings], List of the active nodes in the source cluster
+    :param cluster_name: string, Name of the target cluster
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :return: Total number of files to be mirrored
     """
-
-    num_threads_per_host = getNumberOfSimultaneousFetchesPerServer(srv_obj)
-    target_cluster_active_nodes = get_target_node_disks(srv_obj, cluster_name)
-    target_cluster_assigned_files = get_target_node_disks_scheduled(srv_obj)
-    required_free_space = srv_obj.getCfg().getFreeSpaceDiskChangeMb()
+    num_threads_per_host = get_num_simultaneous_fetches_per_server(ngams_server)
+    target_cluster_active_nodes = get_target_node_disks(ngams_server, cluster_name)
+    target_cluster_assigned_files = get_target_node_disks_scheduled(ngams_server)
+    required_free_space = ngams_server.getCfg().getFreeSpaceDiskChangeMb()
     assigner = TargetVolumeAssigner(target_cluster_active_nodes, target_cluster_assigned_files, required_free_space)
     available_target_hosts = assigner.remove_hosts_without_available_threads(num_threads_per_host)
     if not available_target_hosts:
-        # in theory we shouldn't have reached this point if there are no threads available. However, the way I calculate
-        # if threads are available is open to errors, and it can be that we only discover at this point that no threads
-        # are actually available.
+        # In theory we shouldn't have reached this point if there are no threads available. However, the way I
+        # calculate if threads are available is open to errors, and it can be that we only discover at this point
+        # that no threads are actually available.
         logger.info("There are no hosts available with threads available for mirroring")
         return 0
 
     assigned_files = {}
     for source_node in source_cluster_active_nodes:
-        logger.info('assigning files from source host %s to target nodes / volumes', source_node)
-
+        logger.info('Assigning files from source host %s to target nodes / volumes', source_node)
         # part1: get the required info from the DB
-        files = get_files_to_mirror_from_node(iteration, source_node, srv_obj)
-
+        files = get_files_to_mirror_from_node(iteration, source_node, ngams_server)
         # part2: assign
         assign_files_to_target_nodes(files, assigner, assigned_files)
 
     # part3: persist the assignments
-    logger.info('persisting the assignments of files to hosts / volumes')
+    logger.info('Persisting the assignments of files to hosts / volumes')
     total_files_to_mirror = 0
     for host, volume in assigned_files:
         file_list = assigned_files[(host, volume)]
         if host is None:
-            logger.error("there is insufficient space available to mirror the files %r", file_list)
+            logger.error("There is insufficient space available to mirror the files %r", file_list)
             continue
-        logger.info("updating mirroring table with %d files which are assigned to %s, %s", len(file_list), host, volume)
+        logger.info("Updating mirroring table with %d files which are assigned to %s, %s", len(file_list), host, volume)
         total_files_to_mirror += len(file_list)
-        # TODO this is going to take a while. If we update 10K rows with a DB roundtrip of 0.01s
-        # then the whole update will take about 2 minutes. Therefore we have to limit the sizes
-        # of each iteration so that we can be receving files while we are fetching the next one.
-        sql = "update ngas_mirroring_bookkeeping set status = 'READY', target_host = {0}, staging_file = {1} "
-        sql += " where iteration = {2} and file_id = {3} and file_version = {4}"
+        # TODO: This is going to take a while. If we update 10K rows with a DB round trip of 0.01s then the whole
+        #  update will take about 2 minutes. Therefore we have to limit the sizes of each iteration so that we can be
+        #  receving files while we are fetching the next one.
+        sql = "update ngas_mirroring_bookkeeping set status = 'READY', target_host = {0}, staging_file = {1} " \
+              "where iteration = {2} and file_id = {3} and file_version = {4}"
         for next_file in file_list:
             args = [host, volume, iteration, next_file[0], next_file[1]]
-            srv_obj.getDb().query2(sql, args=args)
+            ngams_server.getDb().query2(sql, args=args)
 
-    # extra part - moved from ngamsCmd_MIRRARCHIVE as a performance optimisation - we already have the information we
+    # Extra part - moved from ngamsCmd_MIRRARCHIVE as a performance optimisation - we already have the information we
     # need here to check if we should mark a disk as complete
     # Check if the disk is completed.
     logger.info('Checking the available disk space remaining after this iteration')
@@ -836,14 +723,14 @@ def assign_mirroring_bookkeeping_entries(iteration,
         if host is None:
             continue
         available_mb = assigner.get_available_bytes(host, volume) / (1024 * 1024)
-        logger.info("available bytes after this iteration for node %s, disk mounted at %s: %s MB", host, volume, available_mb)
+        logger.info("Available bytes after this iteration for node %s, disk mounted at %s: %s MB", host, volume,
+                    available_mb)
         # Check if the disk is completed.
-        if available_mb < srv_obj.getCfg().getFreeSpaceDiskChangeMb():
-            logger.info('disk on host %s at mount point %s has less than %s mb - marking as complete', host, volume, srv_obj.getCfg().getFreeSpaceDiskChangeMb())
+        if available_mb < ngams_server.getCfg().getFreeSpaceDiskChangeMb():
+            logger.info('Disk on host %s at mount point %s has less than %s mb - marking as complete', host, volume,
+                        ngams_server.getCfg().getFreeSpaceDiskChangeMb())
             sql = "update ngas_disks set completed = 1 where last_host_id = {0} and mount_point = {1}"
             unqualified_host_name = re.sub(r"\..*:", ":", host)
-            srv_obj.getDb().query2(sql, args=(unqualified_host_name, volume))
+            ngams_server.getDb().query2(sql, args=(unqualified_host_name, volume))
 
     return total_files_to_mirror
-
-# EOF

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
@@ -19,7 +19,7 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
-#******************************************************************************
+# *****************************************************************************
 #
 # "@(#) $Id: ngamsDAPIMirroring.py,v 1.5 2012/01/30 19:06:15 amanning Exp $"
 #
@@ -28,189 +28,164 @@
 # awicenec  2008/04/10  Created
 #
 """
-This Data Archiving Plug-In is used to handle reception and processing
-of SDM multipart related message files containing Content-Location UIDs.
+This Data Archiving Plug-In is used to handle reception and processing of SDM multipart related message files
+containing Content-Location UIDs.
 
-Note, that the plug-in is implemented for the usage for ALMA. If used in other
-contexts, a dedicated plug-in matching the individual context should be
-implemented and NG/AMS configured to use it.
+Note that the plug-in is implemented for the usage for ALMA. If used in other contexts, a dedicated plug-in matching
+the individual context should be implemented and NG/AMS configured to use it.
 """
 
+import cgi
 import logging
 import os
+import re
+import rfc822
 
 from ngamsLib import ngamsPlugInApi
 from ngamsLib.ngamsCore import genLog, toiso8601, FMT_DATE_ONLY
 
-
 logger = logging.getLogger(__name__)
 
+_EXT = '.msg'
 _PLUGIN_ID = __name__
 
-def specificTreatment(fo):
+
+def specific_treatment(file_object):
     """
-    Method contains the specific treatment of the file passed from NG/AMS.
-
-    fo:         File object
-
-    Returns:    (file_id, finalFileName, type);
-                The finalFileName is a string containing the name of the final
-                file without extension. type is the mime-type from the header.
+    Method contains the specific treatment of the file passed from NG/AMS
+    :param file_object: File object
+    :return: (file_id, finalFileName, type); The finalFileName is a string containing the name of the final file without extension. type is the mime-type from the header.
     """
-    import rfc822, cgi, re
-    _EXT = '.msg'
-
-    filename = fo.name
-
-    uidTempl = re.compile("^[uU][iI][dD]://[aAbBcCzZxX][0-9,a-z,A-Z]+(/[xX][0-9,a-z,A-Z]+){2}(#\w{1,}|/\w{0,}){0,}$")
+    filename = file_object.name
+    uid_template = re.compile("^[uU][iI][dD]://[aAbBcCzZxX][0-9,a-z,A-Z]+(/[xX][0-9,a-z,A-Z]+){2}(#\w{1,}|/\w{0,}){0,}$")
 
     try:
-        message = rfc822.Message(fo)
-        type, tparams = cgi.parse_header(message["Content-Type"])
+        message = rfc822.Message(file_object)
+        type, type_params = cgi.parse_header(message["Content-Type"])
     except Exception as e:
-        err = "Parsing of mime message failed: " + str(e)
-        errMsg = genLog("NGAMS_ER_DAPI_BAD_FILE", [os.path.basename(filename),_PLUGIN_ID, err])
-        raise Exception(errMsg)
+        error_message = "Parsing of mime message failed: " + str(e)
+        exception_message = genLog("NGAMS_ER_DAPI_BAD_FILE", [os.path.basename(filename), _PLUGIN_ID, error_message])
+        raise Exception(exception_message)
+
     try:
-        almaUid = message["alma-uid"]
+        alma_uid = message["alma-uid"]
     except:
         try:
-            almaUid = message["Content-Location"]
+            alma_uid = message["Content-Location"]
         except:
-            err = "Mandatory alma-uid or Content-Location parameter not found in mime header!"
-            errMsg = genLog("NGAMS_ER_DAPI_BAD_FILE", [os.path.basename(filename),_PLUGIN_ID, err])
-            raise Exception(errMsg)
+            error_message = "Mandatory alma-uid or Content-Location parameter not found in mime header!"
+            exception_message = genLog("NGAMS_ER_DAPI_BAD_FILE", [os.path.basename(filename), _PLUGIN_ID, error_message])
+            raise Exception(exception_message)
 
-    if not uidTempl.match(almaUid):
-        err = "Invalid alma-uid found in Content-Location: " + almaUid
-        errMsg = genLog("NGAMS_ER_DAPI_BAD_FILE", [os.path.basename(filename),_PLUGIN_ID, err])
-        raise Exception(errMsg)
+    if not uid_template.match(alma_uid):
+        error_message = "Invalid alma-uid found in Content-Location: " + alma_uid
+        exception_message = genLog("NGAMS_ER_DAPI_BAD_FILE", [os.path.basename(filename), _PLUGIN_ID, error_message])
+        raise Exception(exception_message)
 
     try:
-        almaUid = almaUid.split('//',2)[1].split('#')[0]
-        if almaUid[-1] == '/': almaUid = almaUid[:-1]
-
-        fileId = almaUid
-        finalFileName = almaUid.replace('/',':')
-
+        alma_uid = alma_uid.split('//',2)[1].split('#')[0]
+        if alma_uid[-1] == '/':
+            alma_uid = alma_uid[:-1]
+        file_id = alma_uid
+        final_file_name = alma_uid.replace('/',':')
     except Exception as e:
-        err = "Problem constructing final file name: " + str(e)
-        errMsg = genLog("NGAMS_ER_DAPI_BAD_FILE", [os.path.basename(filename),_PLUGIN_ID, err])
-        raise Exception(errMsg)
+        error_message = "Problem constructing final file name: " + str(e)
+        exception_message = genLog("NGAMS_ER_DAPI_BAD_FILE", [os.path.basename(filename),_PLUGIN_ID, error_message])
+        raise Exception(exception_message)
+
+    return file_id, final_file_name, type
 
 
-    return (fileId, finalFileName, type)
+def generate_file_info(ngams_config, target_disk_info, staging_filename, file_version, base_filename,
+                       subdirectory_list=[], additional_extension_list=[]):
 
+    relative_path = ngams_config.getPathPrefix()
 
-def genFileInfo(dbConObj,
-                ngamsCfgObj,
-                reqPropsObj,
-                trgDiskInfoObj,
-                stagingFilename,
-                fileId,
-                fileVersion,
-                baseFilename,
-                subDirs = [],
-                addExts = []):
+    for subdirectory in subdirectory_list:
+        if relative_path != "":
+            relative_path += "/" + subdirectory
 
-    relPath = ngamsCfgObj.getPathPrefix()
-    for subDir in subDirs:
-        if (relPath != ""): relPath += "/" + subDir
-    relPath = relPath + "/" + str(fileVersion)
-    relPath = relPath.strip("/")
-    complPath = os.path.normpath(trgDiskInfoObj.getMountPoint()+"/"+relPath)
-    ext = os.path.basename(stagingFilename).split(".")[-1]
-    newFilename = baseFilename
-    if not baseFilename.endswith(ext):
-        newFilename = newFilename + "." + ext
-    for addExt in addExts:
-        if (addExt.strip() != ""): newFilename += "." + addExt
-    complFilename = os.path.normpath(complPath + "/" + newFilename)
-    relFilename = os.path.normpath(relPath + "/" + newFilename)
-    logger.debug("Target name for file is: %s", complFilename)
+    relative_path = relative_path + "/" + str(file_version)
+    relative_path = relative_path.strip("/")
+    complete_path = os.path.normpath(target_disk_info.getMountPoint() + "/" + relative_path)
+    extension = os.path.basename(staging_filename).split(".")[-1]
+    new_filename = base_filename
+
+    if not base_filename.endswith(extension):
+        new_filename = new_filename + "." + extension
+
+    for additional_extension in additional_extension_list:
+        if additional_extension.strip() != "":
+            new_filename += "." + additional_extension
+
+    complete_filename = os.path.normpath(complete_path + "/" + new_filename)
+    relative_filename = os.path.normpath(relative_path + "/" + new_filename)
+    logger.debug("Target name for file is: %s", complete_filename)
 
     # We already know that the file does not exist
-    fileExists = 0
+    file_exists = 0
+    return relative_path, relative_filename, complete_filename, file_exists
 
-    return [relPath, relFilename, complFilename, fileExists]
 
-def ngamsGeneric(srvObj,reqPropsObj):
+def ngamsGeneric(ngams_server, request_properties):
     """
-    Data Archiving Plug-In to handle archiving of SDM multipart related
-    message files containing ALMA UIDs in the Content-Location mime parameter
-    or any other kind of file
-
-    srvObj:       Reference to NG/AMS Server Object (ngamsServer).
-
-    reqPropsObj:  NG/AMS request properties object (ngamsReqProps).
-
-    Returns:      Standard NG/AMS Data Archiving Plug-In Status
-                  as generated by: ngamsPlugInApi.genDapiSuccessStat()
-                  (ngamsDapiStatus).
+    Data Archiving Plug-In to handle archiving of SDM multipart related message files containing ALMA UIDs in the
+    Content-Location mime parameter or any other kind of file
+    :param ngams_server: Reference to NG/AMS Server Object (ngamsServer)
+    :param request_properties: NG/AMS request properties object (ngamsReqProps)
+    :return: Standard NG/AMS Data Archiving Plug-In Status as generated by: ngamsPlugInApi.genDapiSuccessStat()
+    (ngamsDapiStatus)
     """
-
-    logger.debug("Mirroring plug-in handling data for file: %s", os.path.basename(reqPropsObj.getFileUri()))
+    logger.debug("Mirroring plug-in handling data for file: %s", os.path.basename(request_properties.getFileUri()))
 
     # Create the file
-    diskInfo = reqPropsObj.getTargDiskInfo()
-    stagingFilename = reqPropsObj.getStagingFilename()
-    ext = os.path.splitext(stagingFilename)[1][1:]
+    disk_info = request_properties.getTargDiskInfo()
+    staging_filename = request_properties.getStagingFilename()
+    # extension = os.path.splitext(staging_filename)[1][1:]
 
-    # reqPropsObj format: /MIRRARCHIVE?mime_type=application/x-tar&filename=...
-    if (reqPropsObj.getMimeType()):
-        format = reqPropsObj.getMimeType()
+    # request_properties format: /MIRRARCHIVE?mime_type=application/x-tar&filename=...
+    if request_properties.getMimeType():
+        file_format = request_properties.getMimeType()
     else:
-        errMsg = "mime_type not specified in MIRRARCHIVE request"
-        raise Exception(errMsg)
+        raise Exception("mime_type paremeter not specified in MIRRARCHIVE request")
 
-    # File Uri format: http://ngasbe03.aiv.alma.cl:7777/RETRIEVE?disk_id=59622720f79296473f6106c15e5c2240&host_id=ngasbe03:7777&quick_location=1&file_version=1&file_id=backup.2011-02-02T22:01:59.tar
+    # File URI format: http://ngasbe03.aiv.alma.cl:7777/RETRIEVE?disk_id=59622720f79296473f6106c15e5c2240&host_id=ngasbe03:7777&quick_location=1&file_version=1&file_id=backup.2011-02-02T22:01:59.tar
 
-    # Get file id
-    fileVersion = reqPropsObj.fileinfo['fileVersion']
-    fileId = reqPropsObj.fileinfo['fileId']
+    # Get file ID
+    file_version = request_properties.fileinfo['fileVersion']
+    file_id = request_properties.fileinfo['fileId']
 
-    # Specific treatment depending on the mime type
-    if ((format.find("multipart") >= 0) or (format.find("multialma") >= 0)):
-        logger.debug("applying plug-in specific treatment")
-        fo = open(stagingFilename, "r")
-        try:
-            (fileId, finalName, format) = specificTreatment(fo)
-        finally:
-            fo.close()
+    # Specific treatment depending on the mime-type
+    if file_format.find("multipart") >= 0 or file_format.find("multialma") >= 0:
+        logger.debug("Applying plug-in specific treatment")
+        with open(staging_filename, "r") as fo:
+            file_id, final_name, file_format = specific_treatment(fo)
     else:
-        finalName = fileId
+        final_name = file_id
 
-    logger.debug("File with URI %s is being handled by ngamsGeneric: format=%s file_id=%s file_version=%s finalName=%s",
-                 reqPropsObj.getFileUri(), format, fileId, fileVersion, finalName)
+    logger.debug("File with URI %s is being handled by ngamsGeneric: file_format=%s, file_id=%s, file_version=%s," 
+                 " final_name=%s", request_properties.getFileUri(), file_format, file_id, file_version, final_name)
 
     try:
         # Compression parameters
-        uncomprSize = ngamsPlugInApi.getFileSize(stagingFilename)
+        uncompressed_size = ngamsPlugInApi.getFileSize(staging_filename)
         compression = ""
 
-        # File name and paths
+        # Filename and paths
         date = toiso8601(fmt=FMT_DATE_ONLY)
-        relPath,relFilename,complFilename,fileExists = genFileInfo(srvObj.getDb(),
-                                                                   srvObj.getCfg(),
-                                                                   reqPropsObj, diskInfo,
-                                                                   stagingFilename, fileId, fileVersion,
-                                                                   finalName, [date])
+        relative_path, relative_filename, complete_filename, file_exists = \
+            generate_file_info(ngams_server.getCfg(), disk_info, staging_filename, file_version, final_name, [date])
+
         # Make sure the format is defined
-        if not format:
-            format = ngamsPlugInApi.determineMimeType(srvObj.getCfg(),stagingFilename)
+        if not file_format:
+            file_format = ngamsPlugInApi.determineMimeType(ngams_server.getCfg(), staging_filename)
 
-        # FileSize
-        fileSize = ngamsPlugInApi.getFileSize(stagingFilename)
+        file_size = ngamsPlugInApi.getFileSize(staging_filename)
 
-        # Return resDapi object
-        return ngamsPlugInApi.genDapiSuccessStat(diskInfo.getDiskId(),
-                                                 relFilename,
-                                                 fileId, fileVersion, format,
-                                                 fileSize, uncomprSize,
-                                                 compression, relPath,
-                                                 diskInfo.getSlotId(),
-                                                 fileExists, complFilename)
+        return ngamsPlugInApi.genDapiSuccessStat(disk_info.getDiskId(), relative_filename, file_id, file_version,
+                                                 file_format, file_size, uncompressed_size, compression, relative_path,
+                                                 disk_info.getSlotId(), file_exists, complete_filename)
     except Exception as e:
-        err = "Problem processing file in stagging area: " + str(e)
-        errMsg = genLog("NGAMS_ER_DAPI_BAD_FILE", [stagingFilename,_PLUGIN_ID, err])
-        raise Exception(errMsg)
+        error_message = "Problem processing file in staging area: " + str(e)
+        exception_message = genLog("NGAMS_ER_DAPI_BAD_FILE", [staging_filename, _PLUGIN_ID, error_message])
+        raise Exception(exception_message)

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
@@ -169,8 +169,9 @@ def ngams_generic(ngams_server, request_properties):
     else:
         final_filename = file_id
 
-    logger.debug("Mirroring plug-in processing request for file with URI %s, file_format=%s, file_id=%s, file_version=%s," 
-                 " final_name=%s", request_properties.getFileUri(), file_format, file_id, file_version, final_filename)
+    logger.debug("Mirroring plug-in processing request for file with URI %s, file_format=%s, file_id=%s, "
+                 "file_version=%s, final_filename=%s", request_properties.getFileUri(), file_format, file_id,
+                 file_version, final_filename)
 
     try:
         # Compression parameters

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
@@ -130,8 +130,9 @@ def ngamsSdmMultipart(ngams_server, request_properties):
 
     file_version = request_properties.getHttpPar("file_version")
 
-    logger.debug("SDM multipart plug-in processing request for file with URI %s, file_format=%s, file_id=%s, file_version=%s," 
-                 " final_name=%s", request_properties.getFileUri(), file_format, file_id, file_version, final_filename)
+    logger.debug("SDM multipart plug-in processing request for file with URI %s, file_format=%s, file_id=%s, "
+                 "file_version=%s, final_filename=%s", request_properties.getFileUri(), file_format, file_id,
+                 file_version, final_filename)
 
     try:
         # Compression parameters

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
@@ -19,7 +19,7 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
-#******************************************************************************
+# *****************************************************************************
 #
 # "@(#) $Id: ngamsSdmMultipart.py,v 1.9 2010/06/29 16:03:42 mbauhofe Exp $"
 #
@@ -29,34 +29,26 @@
 # mbauhofe  2010/06/29  Corrected exception handling.
 #
 """
-This Data Archiving Plug-In is used to handle reception and processing
-of SDM multipart related message files containing Content-Location UIDs.
+This Data Archiving Plug-In is used to handle reception and processing of SDM multipart related message files
+containing Content-Location UIDs.
 
-Note, that the plug-in is implemented for the usage for ALMA. If used in other
-contexts, a dedicated plug-in matching the individual context should be
-implemented and NG/AMS configured to use it.
+Note that the plug-in is implemented for the usage for ALMA. If used in other contexts, a dedicated plug-in matching
+the individual context should be implemented and NG/AMS configured to use it.
 """
 
-from datetime import date
 import email
 import logging
 import os
 import re
 import sys
 
-from ngamsLib import ngamsCore, ngamsPlugInApi
+from ngamsLib import ngamsPlugInApi
+from ngamsLib import ngamsCore
 from ngamsLib.ngamsCore import genLog
 
-# EXT = '.msg'
 PLUGIN_ID = __name__
 
-# This matches the old UID of type X0123456789abcdef/X01234567
-# UID_EXPRESSION = re.compile("[xX][0-9,a-f]{3,}/[xX][0-9,a-f]{1,}$")
-
-# This matches the new UID structure uid://X1/X2/X3#kdgflf
-# UID_EXPRESSION = re.compile("^[uU][iI][dD]:/(/[xX][0-9,a-f,A-F]+){3}(#\w{1,}|/\w{0,}){0,}$")
-
-# Update for the new assignment of archiveIds (backwards compatible)
+# Update for the new assignment of archive IDs (backwards compatible)
 UID_EXPRESSION = re.compile(r"^[uU][iI][dD]://[aAbBcCzZxX][0-9,a-z,A-Z]+(/[xX][0-9,a-z,A-Z]+){2}(#\w{1,}|/\w{0,}){0,}$")
 
 # Python 2/3 workaround
@@ -69,144 +61,100 @@ logger = logging.getLogger(__name__)
 
 def specific_treatment(file_path):
     """
-    Method contains the specific treatment of the file passed from NG/AMS.
-
-    file_path:  File path
-
-    Returns:    (file_id, finalFileName, type);
-                The finalFileName is a string containing the name of the final
-                file without extension. type is the mime-type from the header.
+    Method contains the specific treatment of the file passed from NG/AMS
+    :param file_path: File path
+    :return: (file_id, final_filename, file_type); The final_filename is a string containing the name of the final
+             file without extension. file_type is the mime-type from the header.
     """
     filename = os.path.basename(file_path)
     try:
-        with open(file_path, 'rb') as file_object:
-            message = message_from_file(file_object)
-            file_type = message.get_content_type()
-    except Exception as ex:
-        error = "Parsing of mime message failed: " + str(ex)
-        error_message = genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, error])
-        raise Exception(error_message)
+        with open(file_path, "rb") as fo:
+            mime_message = message_from_file(fo)
+    except Exception as e:
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "Failed to open file: " + str(e)]))
 
-    # First we try looking up the 'alma-uid' header
-    alma_uid = message["alma-uid"]
+    if mime_message is None:
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE",
+                               [filename, PLUGIN_ID, "Failed to parse mime message"]))
 
-    # Then we try looking up the 'Content-Location' header
+    file_type = mime_message.get_content_type()
+    alma_uid = mime_message["alma-uid"]
     if alma_uid is None:
-        alma_uid = message["Content-Location"]
-
-    # Otherwise we throw an exception
+        alma_uid = mime_message["Content-Location"]
     if alma_uid is None:
-        error = "Mandatory alma-uid or Content-Location parameter not found in mime header!"
-        error_message = genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, error])
-        raise Exception(error_message)
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE",
+                               [filename, PLUGIN_ID,
+                                "Mandatory 'alma-uid' and/or 'Content-Location' parameter not found in mime header!"]))
 
-    if not UID_EXPRESSION.match(alma_uid):
-        error = "Invalid alma-uid found in Content-Location: " + str(alma_uid)
-        error_message = genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, error])
-        raise Exception(error_message)
+    if UID_EXPRESSION.match(alma_uid) is None:
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE",
+                               [filename, PLUGIN_ID, "Invalid alma-uid found in Content-Location: " + alma_uid]))
 
-    # Now, build final filename. We do that by looking for the UID in
-    # the message mime-header.
-    #
-    # The final filename is built as follows: <almaUidR>.<ext>
-    # where almaUidR has the slash character in the UID replaced by colons.
+    # Now, build final filename. We do that by looking for the UID in the message mime-header.
+    # The final filename is built as follows: <ALMA-UID>.<EXT> where ALMA-UID has the slash character in the UID
+    # replaced by colons.
     try:
         # Get rid of the 'uid://' and of anything following a '#' sign
-        alma_uid = alma_uid.split('//', 2)[1].split('#')[0]
-
+        alma_uid = alma_uid.split("//", 2)[1].split("#")[0]
         # Remove trailing '/'
         alma_uid = alma_uid.rstrip("/")
-
         file_id = alma_uid
-        final_filename = alma_uid.replace('/', ':')
-
-        # Have no idea why, but the extension is added somewhere else
-        # if os.path.splitext(final_filename)[-1] != EXT:
-        #     final_filename += EXT
-    except Exception as ex:
-        error = "Problem constructing final file name: " + str(ex)
-        error_message = genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, error])
-        raise Exception(error_message)
+        final_filename = alma_uid.replace("/", ":")
+    except Exception as e:
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE",
+                               [filename, PLUGIN_ID, "Problem constructing final file name: " + str(e)]))
 
     return file_id, final_filename, file_type
 
 
-def ngamsSdmMultipart(server_object, request_object):
+def ngamsSdmMultipart(ngams_server, request_properties):
     """
-    Data Archiving Plug-In to handle archiving of SDM multipart related
-    message files containing ALMA UIDs in the Content-Location mime parameter.
-
-    server_object:  Reference to NG/AMS Server Object (ngamsServer).
-
-    request_object: NG/AMS request properties object (ngamsReqProps)
-
-    Returns:        Standard NG/AMS Data Archiving Plug-In Status
-                    as generated by: ngamsPlugInApi.genDapiSuccessStat()
-                    (ngamsDapiStatus)
+    Data Archiving Plug-In to handle archiving of SDM multipart related message files containing ALMA UIDs in the
+    Content-Location mime parameter
+    :param ngams_server: Reference to NG/AMS Server Object (ngamsServer)
+    :param request_properties: NG/AMS request properties object (ngamsReqProps)
+    :return: Standard NG/AMS Data Archiving Plug-In Status as generated by: ngamsPlugInApi.genDapiSuccessStat()
+             (ngamsDapiStatus)
     """
-
     # For now the exception handling is pretty basic:
-    # If something goes wrong during the handling it is tried to
-    # move the temporary file to the Bad Files Area of the disk.
-    logger.info("Plug-In handling data for file: %s",
-                os.path.basename(request_object.getFileUri()))
-    disk_info = request_object.getTargDiskInfo()
-    staging_filename = request_object.getStagingFilename()
-    # extension = os.path.splitext(staging_filename)[1][1:]
+    # If something goes wrong during the handling it is tried to move the temporary file to the bad-files directory
+    logger.info("SDM multipart plug-in handling data for file: %s", os.path.basename(request_properties.getFileUri()))
+
+    disk_info = request_properties.getTargDiskInfo()
+    staging_filename = request_properties.getStagingFilename()
 
     file_id, final_filename, file_format = specific_treatment(staging_filename)
 
-    if request_object.hasHttpPar('file_id'):
-        file_id = request_object.getHttpPar('file_id')
+    if request_properties.hasHttpPar("file_id"):
+        file_id = request_properties.getHttpPar("file_id")
+
+    file_version = request_properties.getHttpPar("file_version")
+
+    logger.debug("SDM multipart plug-in processing request for file with URI %s, file_format=%s, file_id=%s, file_version=%s," 
+                 " final_name=%s", request_properties.getFileUri(), file_format, file_id, file_version, final_filename)
 
     try:
-        # Compress the file
+        # Compression parameters
         uncompressed_size = ngamsPlugInApi.getFileSize(staging_filename)
         compression = ""
 
-        # logger.info("Compressing file %s using %s compression",
-        #             staging_filename, compression)
-        # exit_code, std_out = ngamsPlugInApi.execCmd("{0} {1}".format(
-        #     compression, staging_filename))
-        # if exit_code != 0:
-        #     error_message = _PLUGIN_ID + ": Problems during archiving! " + \
-        #                     "Compressing the file failed"
-        #     raise Exception(error_message)
-        # staging_filename = staging_filename + ".Z"
-        # logger.info("Finished compressing staging file %s", staging_filename)
+        # Remember to update the temporary file name in the request properties object
+        request_properties.setStagingFilename(staging_filename)
 
-        # Remember to update the temporary file name in the request
-        # properties object
-        request_object.setStagingFilename(staging_filename)
+        today = ngamsCore.toiso8601(fmt=ngamsCore.FMT_DATE_ONLY)
+        file_version, relative_path, relative_filename, complete_filename, file_exists = \
+            ngamsPlugInApi.genFileInfo(ngams_server.getDb(), ngams_server.getCfg(), request_properties, disk_info,
+                                       staging_filename, file_id, final_filename, [today])
 
-        # # ToDo: Handling of non-existing fileId
-        # if file_id == -1:
-        #     file_id = ngamsPlugInApi.genNgasId(server_object.getCfg())
-
-        today = date.today().isoformat()
-        file_version, relative_path, relative_filename, complete_filename,\
-        file_exists = ngamsPlugInApi.genFileInfo(server_object.getDb(),
-                                                 server_object.getCfg(),
-                                                 request_object, disk_info,
-                                                 staging_filename, file_id,
-                                                 final_filename, [today])
-
-        logger.debug("Generating status ...")
+        # Make sure the format is defined
         if not file_format:
-            file_format = ngamsPlugInApi.determineMimeType(server_object.getCfg(),
-                                                           staging_filename)
+            file_format = ngamsPlugInApi.determineMimeType(ngams_server.getCfg(), staging_filename)
 
         file_size = ngamsPlugInApi.getFileSize(staging_filename)
-        return ngamsPlugInApi.genDapiSuccessStat(disk_info.getDiskId(),
-                                                 relative_filename, file_id,
-                                                 file_version, file_format,
-                                                 file_size, uncompressed_size,
-                                                 compression, relative_path,
-                                                 disk_info.getSlotId(),
-                                                 file_exists,
-                                                 complete_filename)
-    except Exception as ex:
-        error_message = genLog("NGAMS_ER_DAPI_BAD_FILE",
-                               [os.path.basename(staging_filename),
-                                PLUGIN_ID, str(ex)])
-        raise Exception(error_message)
+
+        return ngamsPlugInApi.genDapiSuccessStat(disk_info.getDiskId(), relative_filename, file_id, file_version,
+                                                 file_format, file_size, uncompressed_size, compression, relative_path,
+                                                 disk_info.getSlotId(), file_exists, complete_filename)
+    except Exception as e:
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE",
+                               [staging_filename, PLUGIN_ID, "Problem processing file in staging area: " + str(e)]))

--- a/src/ngamsServer/ngamsServer/ngamsMirroringControlThread.py
+++ b/src/ngamsServer/ngamsServer/ngamsMirroringControlThread.py
@@ -19,7 +19,7 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
-#******************************************************************************
+# *****************************************************************************
 #
 # "@(#) $Id: ngamsMirroringControlThread.py,v 1.27 2010/06/18 12:03:55 awicenec Exp $"
 #
@@ -28,16 +28,14 @@
 # jknudstr  27/03/2008  Created
 #
 """
-This module contains the code for the Mirroring Control Thread, which is used
-to coordinate the mirroring of the local NGAS Cluster with other NGAS Clusters.
+This module contains the code for the Mirroring Control Thread, which is used to coordinate the mirroring of the
+local NGAS Cluster with other NGAS Clusters.
 
-The NGAS Mirroring Service is running as a background service which does not
-consume soo many resources for the general command handling.
+The NGAS Mirroring Service is running as a background service which does not consume so many resources for the
+general command handling.
 """
-# TODO:
-#   - Detailed reporting not yet implemented.
-# Various definitions used within this module.
-# Definitions for internal DBM based queues used.
+
+# TODO: Detailed reporting not yet implemented
 
 import base64
 import contextlib
@@ -49,1312 +47,991 @@ import random
 import threading
 import time
 
-from ngamsLib.ngamsCore import NGAMS_MIR_CONTROL_THR, rmFile, \
-    NGAMS_HTTP_PAR_FILENAME, NGAMS_HTTP_HDR_FILE_INFO, \
-    NGAMS_HTTP_HDR_CONTENT_TYPE, NGAMS_REARCHIVE_CMD, NGAMS_HTTP_SUCCESS, \
-    NGAMS_STATUS_CMD, decompressFile, \
+from ngamsLib.ngamsCore import \
+    FMT_TIME_ONLY_NOMSEC, \
+    NGAMS_HTTP_HDR_FILE_INFO, \
+    NGAMS_HTTP_HDR_CONTENT_TYPE,\
+    NGAMS_HTTP_SUCCESS, \
+    NGAMS_HTTP_PAR_FILE_LIST,\
     NGAMS_HTTP_PAR_FILE_LIST_ID, \
-    NGAMS_HTTP_PAR_FILE_LIST, NGAMS_HTTP_PAR_UNIQUE, NGAMS_HTTP_PAR_MAX_ELS, \
-    NGAMS_HTTP_PAR_FROM_ING_DATE, get_contact_ip,\
-    toiso8601, FMT_TIME_ONLY_NOMSEC
+    NGAMS_HTTP_PAR_FILENAME,\
+    NGAMS_HTTP_PAR_FROM_ING_DATE, \
+    NGAMS_HTTP_PAR_MAX_ELS, \
+    NGAMS_HTTP_PAR_UNIQUE,\
+    NGAMS_MIR_CONTROL_THR, \
+    NGAMS_REARCHIVE_CMD,\
+    NGAMS_STATUS_CMD,  \
+    decompressFile, get_contact_ip, rmFile, toiso8601
 from ngamsLib import ngamsFileInfo, ngamsStatus, ngamsHighLevelLib, ngamsDbm, \
-    ngamsMirroringRequest, ngamsLib, ngamsHttpUtils
-
+    NgamsMirroringRequest, ngamsLib, ngamsHttpUtils
 
 logger = logging.getLogger(__name__)
 
-NGAMS_MIR_QUEUE_DBM          = "MIR_QUEUE"
-NGAMS_MIR_ERR_QUEUE_DBM      = "MIR_ERROR_QUEUE"
-NGAMS_MIR_COMPL_QUEUE_DBM    = "MIR_COMPLETED_QUEUE"
-NGAMS_MIR_DBM_COUNTER        = "MIR_DBM_COUNTER"
-NGAMS_MIR_DBM_POINTER        = "MIR_DBM_POINTER"
-NGAMS_MIR_FILE_LIST_RAW      = "MIR_FILE_LIST_RAW"
-NGAMS_MIR_CLUSTER_FILE_DBM   = "MIR_CLUSTER_FILE_INFO"
-NGAMS_MIR_DBM_MAX_LIMIT      = (2**30)
+# Various definitions used within this module.
+# Definitions for internal DBM based queues used.
+NGAMS_MIR_QUEUE_DBM = "MIR_QUEUE"
+NGAMS_MIR_ERR_QUEUE_DBM = "MIR_ERROR_QUEUE"
+NGAMS_MIR_COMPL_QUEUE_DBM = "MIR_COMPLETED_QUEUE"
+NGAMS_MIR_DBM_COUNTER = "MIR_DBM_COUNTER"
+NGAMS_MIR_DBM_POINTER = "MIR_DBM_POINTER"
+NGAMS_MIR_FILE_LIST_RAW = "MIR_FILE_LIST_RAW"
+NGAMS_MIR_CLUSTER_FILE_DBM = "MIR_CLUSTER_FILE_INFO"
+NGAMS_MIR_DBM_MAX_LIMIT = (2**30)
 NGAMS_MIR_MIR_THREAD_TIMEOUT = 10.0
-NGAMS_MIR_SRC_ARCH_INF_DBM   = "MIR_SRC_ARCH_INFO"
-NGAMS_MIR_ALL_LOCAL_SRVS     = "ALL"
+NGAMS_MIR_SRC_ARCH_INF_DBM = "MIR_SRC_ARCH_INFO"
+NGAMS_MIR_ALL_LOCAL_SRVS = "ALL"
 
-# Used as exception message when the thread is stopping execution
-# (deliberately).
+# Used as exception message when the thread is stopping execution (deliberately)
 NGAMS_MIR_CONTROL_THR_STOP = "_STOP_MIR_CONTROL_THREAD_"
+
 
 def _finish_thread():
     logger.info("Stopping the Mirroring Service")
     raise Exception(NGAMS_MIR_CONTROL_THR_STOP)
 
-def checkStopMirControlThread(stop_evt):
-    """
-    Used to check if the Mirroring Control Thread should be stopped and in case
-    yes, to stop it.
 
-    srvObj:     Reference to server object (ngamsServer).
-
-    Returns:    Void.
+def check_stop_mirror_control_thread(stop_event):
     """
-    if stop_evt.is_set():
+    Used to check if the Mirroring Control Thread should be stopped and in case yes, to stop it.
+    :param stop_event: Stop event
+    """
+    if stop_event.is_set():
         _finish_thread()
 
-def suspend(stop_evt, t):
-    if stop_evt.wait(t):
+
+def suspend(stop_event, thread):
+    if stop_event.wait(thread):
         _finish_thread()
 
-def addEntryMirQueue(srvObj,
-                     mirReqObj,
-                     updateDb = True):
+
+def add_entry_mirror_queue(ngams_server, mirror_request, update_db=True):
     """
-    Add (schedule) a new Mirroring Request in the internal DBM Mirroring Queue.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    mirReqObj:  Instance of Mirroring Request Object to schedule
-                (ngamsMirroringRequest).
-
-    updateDb:   If true, the status is updated in the DB (boolean).
-
-    Returns:    Void.
+    Add (schedule) a new Mirroring Request in the internal DBM Mirroring Queue
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param mirror_request: Instance of Mirroring Request Object to schedule (ngamsMirroringRequest)
+    :param update_db: If true, the status is updated in the DB (boolean)
     """
     try:
-        srvObj._mirQueueDbmSem.acquire()
-        logger.debug("Adding entry in Mirroring Queue: %s/%d",
-             mirReqObj.getFileId(), mirReqObj.getFileVersion())
-        newKey = ((srvObj._mirQueueDbm.get(NGAMS_MIR_DBM_COUNTER) + 1) %\
-                  NGAMS_MIR_DBM_MAX_LIMIT)
-        srvObj._mirQueueDbm.\
-                              add(str(newKey), mirReqObj).\
-                              add(NGAMS_MIR_DBM_COUNTER, newKey).sync()
-        if (updateDb): srvObj.getDb().updateMirReq(mirReqObj)
-        srvObj._mirQueueDbmSem.release()
+        ngams_server._mirQueueDbmSem.acquire()
+        logger.debug("Adding entry in Mirroring Queue: %s/%d", mirror_request.get_file_id(),
+                     mirror_request.getFileVersion())
+        new_key = (ngams_server._mirQueueDbm.get(NGAMS_MIR_DBM_COUNTER) + 1) % NGAMS_MIR_DBM_MAX_LIMIT
+        ngams_server._mirQueueDbm.add(str(new_key), mirror_request).add(NGAMS_MIR_DBM_COUNTER, new_key).sync()
+        if update_db:
+            ngams_server.getDb().updateMirReq(mirror_request)
+        ngams_server._mirQueueDbmSem.release()
     except Exception as e:
-        srvObj._mirQueueDbmSem.release()
-        msg = "Error adding new element to DBM Mirroring Queue. Error: %s" %\
-              str(e)
-        raise Exception(msg)
+        ngams_server._mirQueueDbmSem.release()
+        raise Exception("Error adding new element to DBM Mirroring Queue. Error: %s" % str(e))
 
 
-def addEntryErrQueue(srvObj,
-                     mirReqObj,
-                     updateDb = True):
+def add_entry_error_queue(ngams_server, mirror_request, update_db=True):
     """
-    Add a Mirroring Request in the internal DBM Mirroring Error Queue.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    mirReqObj:  Instance of Mirroring Request Object to schedule
-                (ngamsMirroringRequest).
-
-    updateDb:   If true, the status is updated in the DB (boolean).
-
-    Returns:    Void.
+    Add (push) a Mirroring Request in the internal DBM Mirroring Error Queue
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param mirror_request: Instance of Mirroring Request Object to schedule (ngamsMirroringRequest)
+    :param update_db: If true, the status is updated in the DB (boolean)
     """
     try:
-        srvObj._errQueueDbmSem.acquire()
-        logger.debug("Adding entry in Mirroring Error Queue: %s/%d",
-             mirReqObj.getFileId(), mirReqObj.getFileVersion())
-        srvObj._errQueueDbm.add(mirReqObj.genFileKey(), mirReqObj).sync()
-        if (updateDb): srvObj.getDb().updateMirReq(mirReqObj)
-        srvObj._errQueueDbmSem.release()
+        ngams_server._errQueueDbmSem.acquire()
+        logger.debug("Adding entry in Mirroring Error Queue: %s/%d", mirror_request.get_file_id(),
+                     mirror_request.getFileVersion())
+        ngams_server._errQueueDbm.add(mirror_request.genFileKey(), mirror_request).sync()
+        if update_db:
+            ngams_server.getDb().updateMirReq(mirror_request)
+        ngams_server._errQueueDbmSem.release()
     except Exception as e:
-        srvObj._errQueueDbmSem.release()
-        msg = "Error adding new element to DBM Mirroring Error Queue. " +\
-              "Error: %s"
-        raise Exception(msg % str(e))
+        ngams_server._errQueueDbmSem.release()
+        raise Exception("Error adding new element to DBM Mirroring Error Queue. Error: %s" % str(e))
 
 
-def popEntryQueue(srvObj,
-                  mirReqObj,
-                  dbm,
-                  dbmSem):
+def pop_entry_queue(mirror_request, dbm, dbm_sem):
     """
-    Get (pop) a Mirroring Request Object from the given DBM queue. The entry is
-    removed from the queue. The entry to get is referenced by its Mirroring
-    Request Object.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    mirReqObj:  Instance of Mirroring Request Object to schedule
-                (ngamsMirroringRequest).
-
-    dbm:        DBM handle to that DBM queue (ngamsDbm).
-
-    dbmSem:     Semaphore controlling access to that queue
-                (threading.Semaphore).
-
-    Return:     Reference to the Mirroring Request Object removed from the
-                Error Queue DBM (ngamsMirroringRequest).
+    Get (pop) a Mirroring Request Object from the given DBM queue. The entry is removed from the queue. The entry to
+    get is referenced by its Mirroring Request Object.
+    :param mirror_request: Instance of Mirroring Request Object to schedule (ngamsMirroringRequest)
+    :param dbm: DBM handle to that DBM queue (ngamsDbm)
+    :param dbm_sem: Semaphore controlling access to that queue (threading.Semaphore)
+    :return: Reference to the Mirroring Request Object removed from the Error Queue DBM (ngamsMirroringRequest)
     """
     try:
-        dbmSem.acquire()
-
-        if (not dbm.hasKey(mirReqObj.genFileKey())):
-            msg = "Mirroring Request: %s not found in DBM Queue: %s"
-            raise Exception(msg % (mirReqObj.genSummary(), dbm.getDbmName()))
-
-        mirReqObj = dbm.get(mirReqObj.genFileKey())
-        dbm.rem(mirReqObj.genFileKey())
-
-        dbmSem.release()
-        return mirReqObj
-
+        dbm_sem.acquire()
+        if not dbm.hasKey(mirror_request.genFileKey()):
+            raise Exception("Mirroring Request: %s not found in DBM Queue: %s"
+                            % (mirror_request.genSummary(), dbm.getDbmName()))
+        mirror_request = dbm.get(mirror_request.genFileKey())
+        dbm.rem(mirror_request.genFileKey())
+        dbm_sem.release()
+        return mirror_request
     except Exception as e:
-        dbmSem.release()
+        dbm_sem.release()
         msg = "Error retrieving element from DBM queue: %s. Error: %s"
         raise Exception(msg % (dbm.getDbmName(), str(e)))
 
 
-def dumpKeysQueue(srvObj,
-                  dbm,
-                  dbmSem,
-                  targetDbmName):
+def dump_keys_queue(dbm, dbm_sem, target_dbm_name):
     """
-    Make a snapshot of all keys in the referenced DBM.
-
-    srvObj:    Reference to server object (ngamsServer).
-
-    dbm:       DBM from which to dump the keys (ngamsDbm).
-
-    dbmSem:    Semaphore used to access that DBM (threading.Semaphore).
-
-    dbmName:   Name of the DBM in which to dump the keys (string).
-
-    Returns:   The final name of the resulting DBM (string).
+    Make a snapshot of all keys in the referenced DBM
+    :param dbm: DBM from which to dump the keys (ngamsDbm)
+    :param dbm_sem: Semaphore used to access that DBM (threading.Semaphore)
+    :param target_dbm_name: Name of the DBM in which to dump the keys (string)
+    :return: The final name of the resulting DBM (string)
     """
-    rmFile("%s*" % targetDbmName)
-    keyDbm = ngamsDbm.ngamsDbm(targetDbmName, cleanUpOnDestr = False,
-                               writePerm = True)
+    rmFile("%s*" % target_dbm_name)
+    key_dbm = ngamsDbm.ngamsDbm(target_dbm_name, cleanUpOnDestr=False, writePerm=True)
     try:
-        dbmSem.acquire()
+        dbm_sem.acquire()
         dbm.initKeyPtr()
-        while (True):
+        while True:
             key, data = dbm.getNext()
-            if (not key): break
-            keyDbm.add(key, data)
-        dbmSem.release()
+            if not key:
+                break
+            key_dbm.add(key, data)
+        dbm_sem.release()
     except Exception as e:
-        dbmSem.release()
-        msg = "Error dumping keys from DBM: %s. Error: %s"
-        raise Exception(msg % (dbm.getDbmName(), str(e)))
-
-    dbmName = keyDbm.sync().getDbmName()
-    return dbmName
+        dbm_sem.release()
+        raise Exception("Error dumping keys from DBM: %s. Error: %s" % (dbm.getDbmName(), str(e)))
+    dbm_name = key_dbm.sync().getDbmName()
+    return dbm_name
 
 
-def addEntryComplQueue(srvObj,
-                       mirReqObj,
-                       updateDb = True):
+def add_entry_completed_queue(ngams_server, mirror_request, update_db=True):
     """
-    Add a Mirroring Request in the DBM Mirroring Completed Queue.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    mirReqObj:  Instance of Mirroring Request Object to put in the queue
-                (ngamsMirroringRequest).
-
-    updateDb:   If true, the status is updated in the DB (boolean).
-
-    Returns:    Void.
+    Add a Mirroring Request in the DBM Mirroring Completed Queue
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param mirror_request: Instance of Mirroring Request Object to put in the queue (ngamsMirroringRequest)
+    :param update_db: If true, the status is updated in the DB (boolean)
     """
     try:
-        srvObj._complQueueDbmSem.acquire()
-        logger.debug("Adding entry in Mirroring Completed Queue: %s/%d",
-             mirReqObj.getFileId(), mirReqObj.getFileVersion())
-        srvObj._complQueueDbm.add(mirReqObj.genFileKey(), mirReqObj).sync()
-        if (updateDb): srvObj.getDb().updateMirReq(mirReqObj)
-        srvObj._complQueueDbmSem.release()
+        ngams_server._complQueueDbmSem.acquire()
+        logger.debug("Adding entry in Mirroring Completed Queue: %s/%d", mirror_request.get_file_id(),
+                     mirror_request.getFileVersion())
+        ngams_server._complQueueDbm.add(mirror_request.genFileKey(), mirror_request).sync()
+        if update_db:
+            ngams_server.getDb().updateMirReq(mirror_request)
+        ngams_server._complQueueDbmSem.release()
     except Exception as e:
-        srvObj._complQueueDbmSem.release()
-        msg = "Error adding new element to DBM Mirroring Completed Queue. " +\
-              "Error: %s"
-        raise Exception(msg % str(e))
+        ngams_server._complQueueDbmSem.release()
+        raise Exception("Error adding new element to DBM Mirroring Completed Queue. Error: %s" % str(e))
 
 
-def scheduleMirReq(srvObj,
-                   instanceId,
-                   fileId,
-                   fileVersion,
-                   ingestionDate,
-                   srvListId,
-                   xmlFileInfo):
+def schedule_mirror_request(ngams_server, instance_id, file_id, file_version, ingestion_date, server_list_id,
+                            xml_file_info):
     """
-    Schedule a new Mirroring Request in the DB Mirroring Queue and the
-    Mirroring Queue DBM.
-
-    srvObj:         Reference to server object (ngamsServer).
-
-    instanceId:     ID for instance controlling the mirroring (string).
-
-    fileId:         NGAS ID of file (string).
-
-    fileVersion:    NGAS version of file (integer).
-
-    ingestionDate:  NGAS ingestion date reference for file (number).
-
-    srvListId:      Server list ID for this request indicating the nodes to
-                    contact to obtain this file (string).
-
-    xmlFileInfo:    The XML file information for the file (string/XML).
-
-    Returns:        Void.
+    Schedule a new Mirroring Request in the DB Mirroring Queue and the Mirroring Queue DBM
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param instance_id: ID for instance controlling the mirroring (string)
+    :param file_id: NGAS file ID (string)
+    :param file_version: NGAS file version (integer)
+    :param ingestion_date: NGAS ingestion date reference for file (number)
+    :param server_list_id: Server list ID for this request indicating the nodes to contact to obtain this file (string)
+    :param xml_file_info: The XML file information for the file (string/XML)
     """
-    mirReqObj = ngamsMirroringRequest.ngamsMirroringRequest().\
-                setInstanceId(instanceId).\
-                setFileId(fileId).\
-                setFileVersion(fileVersion).\
-                setIngestionDate(ingestionDate).\
-                setSrvListId(srvListId).\
-                setStatus(ngamsMirroringRequest.NGAMS_MIR_REQ_STAT_SCHED).\
-                setXmlFileInfo(xmlFileInfo)
-    logger.debug("Scheduling data object for mirroring: %s",
-         mirReqObj.genSummary())
-    srvObj.getDb().writeMirReq(mirReqObj)
-    addEntryMirQueue(srvObj, mirReqObj, updateDb = False)
+    mirror_request_obj = NgamsMirroringRequest.NgamsMirroringRequest().\
+        set_instance_id(instance_id).\
+        set_file_id(file_id).\
+        set_file_version(file_version).\
+        setIngestionDate(ingestion_date).\
+        setSrvListId(server_list_id).\
+        setStatus(NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_SCHED).\
+        setXmlFileInfo(xml_file_info)
+    logger.debug("Scheduling data object for mirroring: %s", mirror_request_obj.genSummary())
+    ngams_server.getDb().writeMirReq(mirror_request_obj)
+    add_entry_mirror_queue(ngams_server, mirror_request_obj, update_db=False)
 
 
-def getMirRequestFromQueue(srvObj):
+def get_mir_request_from_queue(ngams_server):
     """
-    Get the next Mirroring Request from the Mirroring Request Queue.
-    If there are no requests in the queue, None is returned.
-
-    The entries are removed (popped) from the queue.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    Returns:    Next Mirroring Request Object or None
-                (ngamsMirroringRequest | None).
+    Get the next Mirroring Request from the Mirroring Request Queue. If there are no requests in the queue, None is
+    returned. The entries are removed (popped) from the queue.
+    :param ngams_server: Reference to server object (ngamsServer)
+    :return: Next Mirroring Request Object or None (ngamsMirroringRequest | None)
     """
     try:
-        srvObj._mirQueueDbmSem.acquire()
-        nextKey = ((srvObj._mirQueueDbm.get(NGAMS_MIR_DBM_POINTER) + 1) %\
-                   NGAMS_MIR_DBM_MAX_LIMIT)
-        if (srvObj._mirQueueDbm.hasKey(str(nextKey))):
-            mirReqObj = srvObj._mirQueueDbm.get(str(nextKey))
-            srvObj._mirQueueDbm.\
-                                  add(NGAMS_MIR_DBM_POINTER, nextKey).\
-                                  rem(str(nextKey)).sync()
+        ngams_server._mirQueueDbmSem.acquire()
+        next_key = (ngams_server._mirQueueDbm.get(NGAMS_MIR_DBM_POINTER) + 1) % NGAMS_MIR_DBM_MAX_LIMIT
+        if ngams_server._mirQueueDbm.hasKey(str(next_key)):
+            mirror_request_obj = ngams_server._mirQueueDbm.get(str(next_key))
+            ngams_server._mirQueueDbm.add(NGAMS_MIR_DBM_POINTER, next_key).rem(str(next_key)).sync()
         else:
-            mirReqObj = None
-        srvObj._mirQueueDbmSem.release()
-        return mirReqObj
-
+            mirror_request_obj = None
+        ngams_server._mirQueueDbmSem.release()
+        return mirror_request_obj
     except Exception as e:
-        srvObj._mirQueueDbmSem.release()
-        msg = "Error adding new element to DBM Mirroring Queue. Error: %s" %\
-              str(e)
-        raise Exception(msg)
+        ngams_server._mirQueueDbmSem.release()
+        raise Exception("Error adding new element to DBM Mirroring Queue. Error: %s" % str(e))
 
 
-def startMirroringThreads(srvObj, stop_evt):
+def start_mirroring_threads(ngams_server, stop_event):
     """
-    Start the Mirroring Threads according to the configuration.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    Returns:    Void.
+    Start the Mirroring Threads according to the configuration
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param stop_event Stop event
     """
-    for thrNo in range(1, (srvObj.getCfg().getMirroringThreads() + 1)):
-        threadId = NGAMS_MIR_CONTROL_THR + "-" + str(thrNo)
-        args = (srvObj, stop_evt)
-        logger.debug("Starting Mirroring Thread: %s", threadId)
-        thrHandle = threading.Thread(None, mirroringThread, threadId, args)
-        thrHandle.setDaemon(0)
-        thrHandle.start()
+    for thread_num in range(1, ngams_server.getCfg().getMirroringThreads() + 1):
+        thread_id = NGAMS_MIR_CONTROL_THR + "-" + str(thread_num)
+        args = (ngams_server, stop_event)
+        logger.debug("Starting Mirroring Thread: %s", thread_id)
+        thread_handle = threading.Thread(None, mirroring_thread, thread_id, args)
+        thread_handle.setDaemon(False)
+        thread_handle.start()
 
 
-def pauseMirThreads(srvObj, stop_evt):
+def pause_mirror_threads(ngams_server, stop_event):
     """
-    Called by the Mirroring Control Thread to request the Mirroring Threads
-    to pause themselves until asked to resume.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    Returns:    Void.
+    Called by the Mirroring Control Thread to request the Mirroring Threads to pause themselves until asked to resume
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param stop_event: Stop event
     """
-    srvObj._pauseMirThreads = True
-    # Wait for all threads to enter pause mode.
-    noOfMirThreads = srvObj.getCfg().getMirroringThreads()
-    while (True):
-        if (srvObj._mirThreadsPauseCount == noOfMirThreads):
+    ngams_server._pauseMirThreads = True
+    # Wait for all threads to enter pause mode
+    num_mirror_threads = ngams_server.getCfg().getMirroringThreads()
+    while True:
+        if ngams_server._mirThreadsPauseCount == num_mirror_threads:
             logger.debug("All Mirroring Threads entered paused mode")
             return
-        suspend(stop_evt, 1)
+        suspend(stop_event, 1)
 
 
-def resumeMirThreads(srvObj, stop_evt):
+def resume_mirror_threads(ngams_server, stop_event):
     """
-    Called by the Mirroring Control Thread to request the Mirroring Threads
-    to resume service after they have been paused.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    Returns:    Void.
+    Called by the Mirroring Control Thread to request the Mirroring Threads to resume service after they have
+    been paused
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param stop_event: Stop event
     """
-    srvObj._pauseMirThreads = False
-    # Wait for all threads to resume service.
-    noOfMirThreads = srvObj.getCfg().getMirroringThreads()
-    while (srvObj._mirThreadsPauseCount > 0):
-        suspend(stop_evt, 1)
+    ngams_server._pauseMirThreads = False
+    # Wait for all threads to resume service
+    while ngams_server._mirThreadsPauseCount > 0:
+        suspend(stop_event, 1)
     logger.debug("All Mirroring Threads resumed service")
 
 
-def pauseMirThread(srvObj, stop_evt):
+def pause_mirror_thread(ngams_server, stop_event):
     """
-    Called by the Mirroring Threads to check if they should pause on request
-    from the Mirroring Control Thread. If yes, they pause themselves until
-    requested to resume or to exit the service.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    Returns:    Void.
+    Called by the Mirroring Threads to check if they should pause on request from the Mirroring Control Thread. If yes,
+    they pause themselves until requested to resume or to exit the service.
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param stop_event: Stop event
     """
-    if (srvObj._pauseMirThreads):
+    if ngams_server._pauseMirThreads:
         logger.debug("Mirroring Thread suspending itself ...")
-        srvObj._mirThreadsPauseCount += 1
-        while (srvObj._pauseMirThreads):
-            suspend(stop_evt, 1)
+        ngams_server._mirThreadsPauseCount += 1
+        while ngams_server._pauseMirThreads:
+            suspend(stop_event, 1)
         logger.debug("Mirroring Thread resuming service ...")
-        srvObj._mirThreadsPauseCount -= 1
+        ngams_server._mirThreadsPauseCount -= 1
 
 
-def getMirRequest(srvObj,
-                  timeout):
+def get_mirror_request(ngams_server, timeout):
     """
-    Check if there is a Mirroring Request in the queue.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    timeout:    Max. timeout to wait for a new request (float).
-
-    Returns:    Return Mirroring Request Object or None if no became available
-                in the specified period of time (ngamsMirroringRequest|None).
+    Check if there is a Mirroring Request in the queue
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param timeout: Max. timeout to wait for a new request (float)
+    :return: Return Mirroring Request Object or None if no became available in the specified period of time
+    (ngamsMirroringRequest | None)
     """
-    srvObj.waitMirTrigger(timeout)
-    mirReqObj = getMirRequestFromQueue(srvObj)
-    return mirReqObj
+    ngams_server.waitMirTrigger(timeout)
+    mirror_request_obj = get_mir_request_from_queue(ngams_server)
+    return mirror_request_obj
 
 
-# An internal list of local serves is kept, to avoid reading this information
-# continuesly from the DB.
-_localSrvList = []
-_lastUpdateLocalSrvList = 0
-def getLocalNauList(srvObj,
-                    localSrvListCfg):
+# TODO: remove these global variables
+# An internal list of local serves is kept, to avoid reading this information continuously from the DB
+_local_server_list = []
+_last_update_local_server_list = 0
+
+
+def get_local_nau_list(ngams_server, local_server_list_cfg):
     """
-    Render the list of local servers that can be contacted for handling
-    the re-archiving of the files from the source archive.
-
-    If 'localSrvListCfg' is 'ALL', all the local servers with archiving
-    capability are considered. If 'localSrvListCfg' is specified, only
-    these are considered. In both cases the resulting list is shuffled
-    randomly to obtain some load balancing.
-
-    srvObj:             Reference to server object (ngamsServer).
-
-    localSrvListCfg:    List with '<Server>:<Port>,...' to be contacted for
-                        re-archiving requests in the local cluster, or 'ALL'
-                        (string).
-
-    Returns:            List of servers that can be contacted (list).
+    Render the list of local servers that can be contacted for handling the re-archiving of the files from the source
+    archive.
+    If 'local_server_list_cfg' is 'ALL', all the local servers with archiving capability are considered. If
+    'localSrvListCfg' is specified, only these are considered. In both cases the resulting list is shuffled randomly
+    to obtain some load balancing.
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param local_server_list_cfg: List with 'server:port,...' to be contacted for re-archiving requests in the local
+    cluster, or 'ALL' (string)
+    :return: List of servers that can be contacted (list)
     """
-    if (localSrvListCfg == NGAMS_MIR_ALL_LOCAL_SRVS):
-        # All local servers should be considered.
-        # Read only the list of local servers ~every minute.
-        global _localSrvList, _lastUpdateLocalSrvList
-        if ((time.time() - _lastUpdateLocalSrvList) > 60):
-            clusterName = srvObj.getHostInfoObj().getClusterName()
-            _localSrvList = srvObj.getDb().\
-                            getClusterReadyArchivingUnits(clusterName)
-            _lastUpdateLocalSrvList = time.time()
-        tmpSrvList = _localSrvList
+    if local_server_list_cfg == NGAMS_MIR_ALL_LOCAL_SRVS:
+        # All local servers should be considered
+        # Read only the list of local servers about every minute
+        global _local_server_list, _last_update_local_server_list
+        if (time.time() - _last_update_local_server_list) > 60:
+            cluster_name = ngams_server.getHostInfoObj().getClusterName()
+            _local_server_list = ngams_server.getDb().getClusterReadyArchivingUnits(cluster_name)
+            _last_update_local_server_list = time.time()
+        tmp_server_list = _local_server_list
     else:
-        # A specific list is given.
-        tmpSrvList = filter(None, localSrvListCfg.split(","))
-
-    # Create copy of list and shuffle it.
-    srvList = copy.deepcopy(tmpSrvList)
-    random.shuffle(srvList)
-
-    return srvList
+        # A specific list is given
+        tmp_server_list = filter(None, local_server_list_cfg.split(","))
+    # Create a copy of the list and shuffle the item order
+    server_list = copy.deepcopy(tmp_server_list)
+    random.shuffle(server_list)
+    return server_list
 
 
-def handleMirRequest(srvObj,
-                     mirReqObj):
+def handle_mirror_request(ngams_server, mirror_request):
     """
-    Handle a Mirroring Request: Attempt to mirror the data object associated
-    to that Mirroring Request.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    mirReqObj:  Mirroring Request Object (ngamsMirroringRequest).
-
-    Returns:    Void.
+    Handle a Mirroring Request: Attempt to mirror the data object associated to that Mirroring Request.
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param mirror_request: Mirroring Request Object (ngamsMirroringRequest)
     """
-    mirReqObj.setStatus(ngamsMirroringRequest.NGAMS_MIR_REQ_STAT_ACTIVE)
-    srvObj.getDb().updateStatusMirReq(mirReqObj.getFileId(),
-                                      mirReqObj.getFileVersion(),
-                                      ngamsMirroringRequest.\
-                                      NGAMS_MIR_REQ_STAT_ACTIVE_NO)
+    mirror_request.setStatus(NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_ACTIVE)
+    ngams_server.getDb().updateStatusMirReq(mirror_request.get_file_id(), mirror_request.getFileVersion(),
+                                            NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_ACTIVE_NO)
 
-    # Find a node to contact in the local cluster (try the whole list
-    # if necessary).
-    srvList = srvObj.getSrvListDic()[mirReqObj.getSrvListId()]
-    mirSrcObj = srvObj.getCfg().getMirroringSrcObjFromSrvList(srvList)
-    localNauList = getLocalNauList(srvObj, mirSrcObj.getTargetNodes())
+    # Find a node to contact in the local cluster (try the whole list if necessary)
+    server_list = ngams_server.getSrvListDic()[mirror_request.getSrvListId()]
+    mirror_source_obj = ngams_server.getCfg().getMirroringSrcObjFromSrvList(server_list)
+    local_nau_list = get_local_nau_list(ngams_server, mirror_source_obj.getTargetNodes())
     succeeded = False
-    encFileInfo = base64.b64encode(mirReqObj.getXmlFileInfo())
-    fileInfoObj = ngamsFileInfo.ngamsFileInfo().\
-                  unpackXmlDoc(mirReqObj.getXmlFileInfo())
-    errMsg = ""
-    for nextNau in localNauList:
-        nextLocalSrv, nextLocalPort = nextNau.split(":")
-        nextLocalPort = int(nextLocalPort)
+    encoded_file_info = base64.b64encode(mirror_request.getXmlFileInfo())
+    file_info = ngamsFileInfo.ngamsFileInfo().unpackXmlDoc(mirror_request.getXmlFileInfo())
+    error_message = ""
+    for next_nau in local_nau_list:
+        next_local_server, next_local_port = next_nau.split(":")
+        next_local_port = int(next_local_port)
 
-        # Cycle over the specified remote nodes in the source archive, until
-        # one of them are successful.
+        # Cycle over the specified remote nodes in the source archive, until one of them are successful
 
         # Get shuffled list of nodes in the source archive to contact to
         # get a copy of the file in question.
-        srcNodeList = copy.deepcopy(srvObj.getSrvListDic()[mirSrcObj.getId()])
-        random.shuffle(srcNodeList)
-        for srcNodeAddress in srcNodeList:
-            srcHostName, srcPortNo = srcNodeAddress.split(":")
-            srcPortNo = int(srcPortNo)
+        source_node_list = copy.deepcopy(ngams_server.getSrvListDic()[mirror_source_obj.getId()])
+        random.shuffle(source_node_list)
+        for source_node_address in source_node_list:
+            source_host_name, source_port_num = source_node_address.split(":")
+            source_port_num = int(source_port_num)
+            # Send REARCHIVE Command to the next, local contact node, asking it to try to collect the file from the
+            # next node in the Mirroring Source Archive.
+            # FIXME: we should try using https
+            file_uri = "http://%s:%d/RETRIEVE?file_id=%s&file_version=%d&quick_location=1"
+            file_uri = file_uri % (source_host_name, source_port_num, mirror_request.get_file_id(),
+                                   mirror_request.getFileVersion())
+            pars = [[NGAMS_HTTP_PAR_FILENAME, file_uri]]
+            hdrs = [[NGAMS_HTTP_HDR_FILE_INFO, encoded_file_info],
+                    [NGAMS_HTTP_HDR_CONTENT_TYPE, file_info.getFormat()]]
+            response = ngamsHttpUtils.httpGet(next_local_server, next_local_port, NGAMS_REARCHIVE_CMD, pars=pars,
+                                              hdrs=hdrs, timeout=600)
 
-            # Send REARCHIVE Command to the next, local contact node, asking
-            # it to try to collect the file from the next node in the
-            # Mirroring Source Archive.
-            fileUri = "http://%s:%d/RETRIEVE?file_id=%s&file_version=%d&quick_location=1"
-            fileUri = fileUri % (srcHostName, srcPortNo, mirReqObj.getFileId(),
-                                 mirReqObj.getFileVersion())
-            pars = [[NGAMS_HTTP_PAR_FILENAME, fileUri]]
-            hdrs = [[NGAMS_HTTP_HDR_FILE_INFO, encFileInfo],
-                    [NGAMS_HTTP_HDR_CONTENT_TYPE, fileInfoObj.getFormat()]]
-            resp = ngamsHttpUtils.httpGet(nextLocalSrv, nextLocalPort,
-                                    NGAMS_REARCHIVE_CMD, pars=pars, hdrs=hdrs,
-                                    timeout=600)
-
-            with contextlib.closing(resp):
-                if resp.status == NGAMS_HTTP_SUCCESS:
+            with contextlib.closing(response):
+                if response.status == NGAMS_HTTP_SUCCESS:
                     succeeded = True
                     break
                 else:
-                    # An error occurred, log error notice and go to next (if there
-                    # are more nodes).
-                    tmpStatObj = ngamsStatus.ngamsStatus().unpackXmlDoc(resp.read())
-                    msg = "Error issuing REARCHIVE Command. " +\
-                          "Local node: %s:%d, source contact node: %s:%d. " +\
+                    # An error occurred, log error notice and go to next (if there are more nodes)
+                    tmp_status = ngamsStatus.ngamsStatus().unpackXmlDoc(response.read())
+                    msg = "Error issuing REARCHIVE Command. Local node: %s:%d, source contact node: %s:%d. " \
                           "Error message: %s"
-                    msg = msg % (nextLocalSrv, nextLocalPort, srcHostName,
-                                 srcPortNo, tmpStatObj.getMessage())
+                    msg = msg % (next_local_server, next_local_port, source_host_name, source_port_num,
+                                 tmp_status.getMessage())
                     logger.warning(msg)
-                    errMsg = "Last error encountered: %s" % msg
+                    error_message = "Last error encountered: %s" % msg
                     continue
+        if succeeded:
+            break
 
-        if (succeeded): break
-
-    if (not succeeded):
-        mirReqObj.\
-                    setStatus(ngamsMirroringRequest.\
-                              NGAMS_MIR_REQ_STAT_ERR_RETRY_NO).\
-                    setMessage(errMsg).\
-                    setLastActivityTime(time.time())
-        srvObj.getDb().updateStatusMirReq(mirReqObj.getFileId(),
-                                          mirReqObj.getFileVersion(),
-                                          ngamsMirroringRequest.\
-                                          NGAMS_MIR_REQ_STAT_ERR_RETRY_NO)
-        msg = "Error handling Mirroring Request: %s" % mirReqObj.genSummary()
-        raise Exception(msg)
+    if not succeeded:
+        mirror_request.setStatus(NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_ERR_RETRY_NO).\
+            setMessage(error_message).setLastActivityTime(time.time())
+        ngams_server.getDb().updateStatusMirReq(mirror_request.get_file_id(), mirror_request.getFileVersion(),
+                                                NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_ERR_RETRY_NO)
+        raise Exception("Error handling Mirroring Request: %s" % mirror_request.genSummary())
     else:
-        msg = "Successfully handled Mirroring Request: %s"
-        logger.debug(msg, mirReqObj.genSummary())
+        logger.debug("Successfully handled Mirroring Request: %s", mirror_request.genSummary())
 
 
-def mirroringThread(srvObj, stop_evt):
+def mirroring_thread(ngams_server, stop_event):
     """
-    A number of Mirroring Threads are executing when the NGAS Mirroring Service
-    is enabled to handle the requesting of data and ingestion into the local
-    clster.
-
-    srvObj:      Reference to server object (ngamsServer).
-
-    dummy:       Needed by the thread handling ...
-
-    Returns:     Void.
+    A number of Mirroring Threads are executing when the NGAS Mirroring Service is enabled to handle the requesting of
+    data and ingestion into the local cluster.
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param stop_event: Stop event
     """
-    # Main loop.
-    while (True):
-        # Incapsulate this whole block to avoid that the thread dies in
-        # case a problem occurs, like e.g. a problem with the DB connection.
+    while True:
+        # Encapsulate this whole block to avoid that the thread dies in case a problem occurs,
+        # like e.g. a problem with the DB connection
         try:
-            checkStopMirControlThread(stop_evt)
-            pauseMirThread(srvObj, stop_evt)
-
+            check_stop_mirror_control_thread(stop_event)
+            pause_mirror_thread(ngams_server, stop_event)
             logger.debug("Mirroring Thread starting next iteration ...")
-
-            ###################################################################
             # Business logic of Mirroring Thread
-            ###################################################################
             try:
-                # Wait for the next Mirroring Request. A timeout is applied,
-                # if no request becomes available within the given timeout
-                # an exception is thrown.
-                mirReqObj = getMirRequest(srvObj, NGAMS_MIR_MIR_THREAD_TIMEOUT)
-                if (mirReqObj):
-                    handleMirRequest(srvObj, mirReqObj)
-
-                    # The handling of the Mirroring Request succeeded (no
-                    # exception was thrown). Put the handle in the Completed
-                    # Queue.
-                    mirReqObj.setStatus(ngamsMirroringRequest.\
-                                        NGAMS_MIR_REQ_STAT_MIR)
-                    fileVer = mirReqObj.getFileVersion()
-                    mirroringStat = ngamsMirroringRequest.\
-                                    NGAMS_MIR_REQ_STAT_MIR_NO
-                    srvObj.getDb().updateStatusMirReq(mirReqObj.getFileId(),
-                                                      fileVer, mirroringStat)
-                    addEntryComplQueue(srvObj, mirReqObj)
+                # Wait for the next Mirroring Request. A timeout is applied, if no request becomes available within
+                # the given timeout an exception is thrown.
+                mirror_request = get_mirror_request(ngams_server, NGAMS_MIR_MIR_THREAD_TIMEOUT)
+                if mirror_request:
+                    handle_mirror_request(ngams_server, mirror_request)
+                    # The handling of the Mirroring Request succeeded (no exception was thrown). Put the handle in the
+                    # Completed Queue.
+                    mirror_request.setStatus(NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_MIR)
+                    file_version = mirror_request.getFileVersion()
+                    mirroring_status = NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_MIR_NO
+                    ngams_server.getDb().updateStatusMirReq(mirror_request.getFileId(), file_version, mirroring_status)
+                    add_entry_completed_queue(ngams_server, mirror_request)
             except Exception as e:
-                if (str(e).find(NGAMS_MIR_CONTROL_THR_STOP) != -1): raise e
-                msg = "Error handling Mirroring Request. Putting in Error " +\
-                      "Queue. Error: %s" % str(e)
-                logger.warning(msg)
-                # Put the request in the Error Queue DBM.
-                statNo = ngamsMirroringRequest.\
-                         NGAMS_MIR_REQ_STAT_ERR_RETRY_NO
-                mirReqObj.\
-                            setStatus(statNo).\
-                            setMessage(str(e))
-                srvObj.getDb().updateStatusMirReq(mirReqObj.getFileId(),
-                                                  mirReqObj.getFileVersion(),
-                                                  statNo)
-                addEntryErrQueue(srvObj, mirReqObj)
-            ###################################################################
-
+                if str(e).find(NGAMS_MIR_CONTROL_THR_STOP) != -1:
+                    raise e
+                logger.warning("Error handling Mirroring Request. Putting in Error Queue. Error: %s" % str(e))
+                # Put the request in the Error Queue DBM
+                stat_num = NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_ERR_RETRY_NO
+                mirror_request.setStatus(stat_num).setMessage(str(e))
+                ngams_server.getDb().updateStatusMirReq(mirror_request.getFileId(), mirror_request.getFileVersion(),
+                                                        stat_num)
+                add_entry_error_queue(ngams_server, mirror_request)
         except Exception as e:
-            if (str(e).find(NGAMS_MIR_CONTROL_THR_STOP) != -1):
+            if str(e).find(NGAMS_MIR_CONTROL_THR_STOP) != -1:
                 return
-            errMsg = "Error occurred during execution of the Mirroring " +\
-                     "Control Thread"
-            logger.exception(errMsg)
-            # We make a small wait here to avoid that the process tries
-            # too often to carry out the tasks that failed.
-            if stop_evt.wait(5.0):
+            logger.exception("Error occurred during execution of the Mirroring Control Thread")
+            # We make a small wait here to avoid that the process tries too often to carry out the tasks that failed
+            if stop_event.wait(5.0):
                 return
 
 
-def initMirroring(srvObj):
+def initialise_mirroring(ngams_server):
     """
-    Initialize the NGAS Mirroring Service. If there are requests in the
-    Mirroring Request Queue in the DB, these are read out and inserted
-    in the local Mirroring Request DBM.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    Returns:    Void.
+    Initialize the NGAS Mirroring Service. If there are requests in the Mirroring Request Queue in the DB, these are
+    read out and inserted in the local Mirroring Request DBM.
+    :param ngams_server: Reference to server object (ngamsServer)
     """
-    hostId = srvObj.getHostId()
-    # Build up the server list in the DB and the local repository kept
-    # in memory.
-    # The ID allocated to each Mirroring Source, is used as ID in the Server
-    # List.
-    for mirSrcObj in srvObj.getCfg().getMirroringSrcList():
-        srvListId = srvObj.getDb().\
-                    getSrvListIdFromSrvList(mirSrcObj.getServerList())
-        srvObj.getSrvListDic()[srvListId] = mirSrcObj.getServerList()
-        srvObj.getSrvListDic()[mirSrcObj.getServerList()] = srvListId
-        # Add compiled version of the list, which is easy to use when
-        # accessing the contact nodes.
-        srvObj.getSrvListDic()[mirSrcObj.getId()] = mirSrcObj.\
-                                                    getServerList().split(",")
+    host_id = ngams_server.getHostId()
+    # Build up the server list in the DB and the local repository kept in memory
+    # The ID allocated to each Mirroring Source, is used as ID in the Server List
+    for mirror_source_obj in ngams_server.getCfg().getMirroringSrcList():
+        server_list_id = ngams_server.getDb().getSrvListIdFromSrvList(mirror_source_obj.getServerList())
+        ngams_server.getSrvListDic()[server_list_id] = mirror_source_obj.getServerList()
+        ngams_server.getSrvListDic()[mirror_source_obj.getServerList()] = server_list_id
+        # Add compiled version of the list, which is easy to use when accessing the contact nodes
+        ngams_server.getSrvListDic()[mirror_source_obj.getId()] = mirror_source_obj.getServerList().split(",")
 
-    # Create the Mirroring DBM Queue.
-    mirQueueDbmName = "%s/%s_%s" %\
-                      (ngamsHighLevelLib.getNgasChacheDir(srvObj.getCfg()),
-                       NGAMS_MIR_QUEUE_DBM, hostId)
-    rmFile("%s*" % mirQueueDbmName)
-    srvObj._mirQueueDbm = ngamsDbm.ngamsDbm(mirQueueDbmName,
-                                            cleanUpOnDestr = 0,
-                                            writePerm = 1)
-    srvObj._mirQueueDbm.\
-                          add(NGAMS_MIR_DBM_COUNTER, 0).\
-                          add(NGAMS_MIR_DBM_POINTER, 0)
+    # Create the Mirroring DBM Queue
+    mirror_queue_dbm_name = "%s/%s_%s" % (ngamsHighLevelLib.getNgasChacheDir(ngams_server.getCfg()),
+                                          NGAMS_MIR_QUEUE_DBM, host_id)
+    rmFile("%s*" % mirror_queue_dbm_name)
+    ngams_server._mirQueueDbm = ngamsDbm.ngamsDbm(mirror_queue_dbm_name, cleanUpOnDestr=0, writePerm=1)
+    ngams_server._mirQueueDbm.add(NGAMS_MIR_DBM_COUNTER, 0).add(NGAMS_MIR_DBM_POINTER, 0)
 
-    # Create the Error DBM Queue.
-    errQueueDbmName = "%s/%s_%s" %\
-                      (ngamsHighLevelLib.getNgasChacheDir(srvObj.getCfg()),
-                       NGAMS_MIR_ERR_QUEUE_DBM, hostId)
-    rmFile("%s*" % errQueueDbmName)
-    srvObj._errQueueDbm = ngamsDbm.ngamsDbm(errQueueDbmName,
-                                            cleanUpOnDestr = 0,
-                                            writePerm = 1)
+    # Create the Error DBM Queue
+    error_queue_dbm_name = "%s/%s_%s" % (ngamsHighLevelLib.getNgasChacheDir(ngams_server.getCfg()),
+                                         NGAMS_MIR_ERR_QUEUE_DBM, host_id)
+    rmFile("%s*" % error_queue_dbm_name)
+    ngams_server._errQueueDbm = ngamsDbm.ngamsDbm(error_queue_dbm_name, cleanUpOnDestr=0, writePerm=1)
 
-    # Create the Completed DBM Queue.
-    complQueueDbmName = "%s/%s_%s" %\
-                        (ngamsHighLevelLib.getNgasChacheDir(srvObj.getCfg()),
-                         NGAMS_MIR_COMPL_QUEUE_DBM, hostId)
-    rmFile("%s*" % complQueueDbmName)
-    srvObj._complQueueDbm = ngamsDbm.ngamsDbm(complQueueDbmName,
-                                              cleanUpOnDestr = 0,
-                                              writePerm = 1)
+    # Create the Completed DBM Queue
+    completed_queue_dbm_name = "%s/%s_%s" % (ngamsHighLevelLib.getNgasChacheDir(ngams_server.getCfg()),
+                                             NGAMS_MIR_COMPL_QUEUE_DBM, host_id)
+    rmFile("%s*" % completed_queue_dbm_name)
+    ngams_server._complQueueDbm = ngamsDbm.ngamsDbm(completed_queue_dbm_name, cleanUpOnDestr=0, writePerm=1)
 
-    # Create the DBM to keep track of when synchronization was last done with
-    # the specified Source Archives. Note this DBM is kept between sessions
-    # to avoid too frequent complete syncrhonization checks.
-    srcArchInfoDbm = "%s/%s_%s" %\
-                     (ngamsHighLevelLib.getNgasChacheDir(srvObj.getCfg()),
-                      NGAMS_MIR_SRC_ARCH_INF_DBM, hostId)
-    srvObj._srcArchInfoDbm = ngamsDbm.ngamsDbm(srcArchInfoDbm,
-                                               cleanUpOnDestr = 0,
-                                               writePerm = 1)
-    # Update the Mirroring Source Archive DBM.
-    for mirSrcObj in srvObj.getCfg().getMirroringSrcList():
-        if (not srvObj._srcArchInfoDbm.hasKey(mirSrcObj.getId())):
-            srvObj._srcArchInfoDbm.add(mirSrcObj.getId(), mirSrcObj)
+    # Create the DBM to keep track of when synchronization was last done with the specified Source Archives. Note this
+    # DBM is kept between sessions to avoid too frequent complete synchronization checks.
+    source_archive_info_dbm = "%s/%s_%s" % (ngamsHighLevelLib.getNgasChacheDir(ngams_server.getCfg()),
+                                            NGAMS_MIR_SRC_ARCH_INF_DBM, host_id)
+    ngams_server._srcArchInfoDbm = ngamsDbm.ngamsDbm(source_archive_info_dbm, cleanUpOnDestr=0, writePerm=1)
+    # Update the Mirroring Source Archive DBM
+    for mirror_source_obj in ngams_server.getCfg().getMirroringSrcList():
+        if not ngams_server._srcArchInfoDbm.hasKey(mirror_source_obj.getId()):
+            ngams_server._srcArchInfoDbm.add(mirror_source_obj.getId(), mirror_source_obj)
         else:
-            dbmMirSrcObj = srvObj._srcArchInfoDbm.get(mirSrcObj.getId())
-            mirSrcObj.setLastSyncTime(dbmMirSrcObj.getLastSyncTime())
-            srvObj._srcArchInfoDbm.add(mirSrcObj.getId(), mirSrcObj)
+            dbm_mirror_source_obj = ngams_server._srcArchInfoDbm.get(mirror_source_obj.getId())
+            mirror_source_obj.setLastSyncTime(dbm_mirror_source_obj.getLastSyncTime())
+            ngams_server._srcArchInfoDbm.add(mirror_source_obj.getId(), mirror_source_obj)
 
-    # Restore the previous state of the mirroring from the DB Mirroring Queue
-    # (if the service was interrupted).
-    for mirReqObj in srvObj.getDb().dumpMirroringQueue(srvObj.getHostId()):
-        logger.debug("Restoring Mirroring Request: %s", mirReqObj.genSummary())
+    # Restore the previous state of the mirroring from the DB Mirroring Queue (if the service was interrupted)
+    for mirror_request_obj in ngams_server.getDb().dumpMirroringQueue(ngams_server.getHostId()):
+        logger.debug("Restoring Mirroring Request: %s", mirror_request_obj.genSummary())
         # Add entry in the Mirroring DBM Queue?
-        if (mirReqObj.getStatusAsNo() in
-            (ngamsMirroringRequest.NGAMS_MIR_REQ_STAT_SCHED_NO,
-             ngamsMirroringRequest.NGAMS_MIR_REQ_STAT_ACTIVE_NO)):
-            addEntryMirQueue(srvObj, mirReqObj)
+        if mirror_request_obj.getStatusAsNo() in (NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_SCHED_NO,
+                                                  NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_ACTIVE_NO):
+            add_entry_mirror_queue(ngams_server, mirror_request_obj)
         # Add entry in the Error DBM Queue?
-        elif (mirReqObj.getStatusAsNo() ==
-              ngamsMirroringRequest.NGAMS_MIR_REQ_STAT_ERR_RETRY_NO):
-            addEntryErrQueue(srvObj, mirReqObj)
+        elif mirror_request_obj.getStatusAsNo() == NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_ERR_RETRY_NO:
+            add_entry_error_queue(ngams_server, mirror_request_obj)
         # Add entry in the Completed DBM Queue?
-        elif (mirReqObj.getStatusAsNo() in
-              (ngamsMirroringRequest.NGAMS_MIR_REQ_STAT_MIR_NO,
-               ngamsMirroringRequest.NGAMS_MIR_REQ_STAT_REP_NO,
-               ngamsMirroringRequest.NGAMS_MIR_REQ_STAT_ERR_ABANDON_NO)):
-            addEntryComplQueue(srvObj, mirReqObj, updateDb = False)
+        elif mirror_request_obj.getStatusAsNo() in (NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_MIR_NO,
+                                                    NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_REP_NO,
+                                                    NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_ERR_ABANDON_NO):
+            add_entry_completed_queue(ngams_server, mirror_request_obj, update_db=False)
 
 
-def retrieveFileList(srvObj,
-                     mirSrcObj,
-                     node,
-                     port,
-                     statusCmdPars,
-                     clusterFilesDbmName):
+def retrieve_file_list(ngams_server, mirror_source, node, port, status_cmd_pars, cluster_files_dbm_name):
     """
-    Retrieve and handle the information in connection with the STATUS?file_list
-    request.
-
-    srvObj:               Reference to server object (ngamsServer).
-
-    mirSrcObj:            Mirroring Source Object associated with the NGAS
-                          Cluster contacted (ngamsMirroringSource).
-
-    node:                 NGAS host to contact (string).
-
-    port:                 Port used by NGAS instance to contact (integer).
-
-    statusCmdPars:        HTTP parameters for the STATUS Command (list).
-
-    clusterFilesDbmName:  Name of the DBM containing a snapshot of all files
-                          stored in the name space of the local cluster
-                          (string).
-
-    Returns:              Void
+    Retrieve and handle the information in connection with the STATUS?file_list request
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param mirror_source: Mirroring Source Object associated with the NGAS Cluster contacted (ngamsMirroringSource)
+    :param node: NGAS host to contact (string)
+    :param port: Port used by NGAS instance to contact (integer)
+    :param status_cmd_pars: HTTP parameters for the STATUS Command (list)
+    :param cluster_files_dbm_name: Name of the DBM containing a snapshot of all files stored in the name space of the
+    local cluster (string)
     """
-    hostId = srvObj.getHostId()
+    host_id = ngams_server.getHostId()
 
-    # Send the STATUS?file_list query. Receive the data into a temporary file.
-    rawFileListCompr = "%s/%s_%s.gz" %\
-                       (ngamsHighLevelLib.getNgasChacheDir(srvObj.getCfg()),
-                        NGAMS_MIR_FILE_LIST_RAW, hostId)
-
-
-    fileListId = None
+    # Send the STATUS?file_list query. Receive the data into a temporary file
+    raw_file_list_compressed = "%s/%s_%s.gz" % (ngamsHighLevelLib.getNgasChacheDir(ngams_server.getCfg()),
+                                                NGAMS_MIR_FILE_LIST_RAW, host_id)
+    file_list_id = None
     try:
-        clusterFilesDbm = ngamsDbm.ngamsDbm(clusterFilesDbmName,
-                                            cleanUpOnDestr = 0, writePerm = 1)
+        cluster_files_dbm = ngamsDbm.ngamsDbm(cluster_files_dbm_name, cleanUpOnDestr=0, writePerm=1)
+        # Retrieve the file info from the specified contact nodes and schedule the files relevant
+        remaining_elements = None
+        while True:
+            rmFile("%s*" % raw_file_list_compressed[:-3])
+            response = ngamsHttpUtils.httpGet(node, port, NGAMS_STATUS_CMD, pars=status_cmd_pars, timeout=1800)
 
-        # Retrieve the file info from the specified contact nodes and
-        # schedule the files relevant.
-        remainingEls = None
-        while (True):
-            rmFile("%s*" % rawFileListCompr[:-3])
-            resp = ngamsHttpUtils.httpGet(node, port, NGAMS_STATUS_CMD,
-                                    pars=statusCmdPars,
-                                    timeout=1800)
+            with contextlib.closing(response):
+                if response.status != NGAMS_HTTP_SUCCESS:
+                    rmFile("%s*" % raw_file_list_compressed[:-3])
+                    status_obj = ngamsStatus.ngamsStatus().unpackXmlDoc(response.read())
+                    raise Exception("Error accessing NGAS Node: %s/%d. Error: %s"
+                                    % (node, port, status_obj.getMessage()))
 
-            with contextlib.closing(resp):
-                if resp.status != NGAMS_HTTP_SUCCESS:
-                    rmFile("%s*" % rawFileListCompr[:-3])
-                    statObj = ngamsStatus.ngamsStatus().unpackXmlDoc(resp.read())
-                    msg = "Error accessing NGAS Node: %s/%d. Error: %s"
-                    raise Exception(msg % (node, port, statObj.getMessage()))
+                with open(raw_file_list_compressed, 'wb') as raw_file_obj:
+                    response_read_buffer = functools.partial(response.read, 65536)
+                    for response_buffer in iter(response_read_buffer, ''):
+                        raw_file_obj.write(response_buffer)
 
-                with open(rawFileListCompr, 'wb') as f:
-                    readf = functools.partial(resp.read, 65536)
-                    for buf in iter(readf, ''):
-                        f.write(buf)
+            # Decompress the file (it is always transferred compressed)
+            file_list_raw = decompressFile(raw_file_list_compressed)
 
-            # Decompress the file (it is always transferred compressed).
-            fileListRaw = decompressFile(rawFileListCompr)
-
-            # Get the File List ID in connection with this request if not
-            # already extracted.
-            # Get the number of remaining items to retrieve info about.
-            # It is necessary to scan through the beginning of the file to
-            # get the FileList Element, which contains this information.
+            # Get the File List ID in connection with this request if not already extracted.
+            # Get the number of remaining items to retrieve info about. It is necessary to scan through the beginning
+            # of the file to get the FileList Element, which contains this information.
             # The entry looks something like this:
-            #
-            # <FileList Id="a8f2cbdb705899588468f72986c813ab"
-            #           Status="REMAINING_DATA_OBJECTS: 1453">
-            fo = open(fileListRaw)
+            # <FileList Id="a8f2cbdb705899588468f72986c813ab" Status="REMAINING_DATA_OBJECTS: 1453">
+            file_list_raw_obj = open(file_list_raw)
             count = 0
-            while (count < 100):
-                nextLine = fo.readline()
-                if (nextLine.find("FileList Id=") != -1):
-                    lineEls = filter(None, nextLine.strip().split(" "))
-                    if (not fileListId):
-                        fileListId = lineEls[1].split("=")[1].strip('"')
-                        statusCmdPars.append([NGAMS_HTTP_PAR_FILE_LIST_ID,
-                                              fileListId])
-                    remainingEls = int(filter(None, lineEls)[-1].split('"')[0])
+            while count < 100:
+                next_line = file_list_raw_obj.readline()
+                if next_line.find("FileList Id=") != -1:
+                    line_elements = filter(None, next_line.strip().split(" "))
+                    if not file_list_id:
+                        file_list_id = line_elements[1].split("=")[1].strip('"')
+                        status_cmd_pars.append([NGAMS_HTTP_PAR_FILE_LIST_ID, file_list_id])
+                    remaining_elements = int(filter(None, line_elements)[-1].split('"')[0])
                     break
                 count += 1
-            msg = "Retrieving File List. File List ID: %s. " +\
-                  "Remaining Elements: %d"
-            logger.debug(msg, fileListId, remainingEls)
-            if (count == 100):
-                msg = "Illegal file list received as response to " +\
-                      "STATUS?file_list Request"
-                raise Exception(msg)
-            fo.seek(0)
+            logger.debug("Retrieving File List. File List ID: %s. Remaining Elements: %d",
+                         file_list_id, remaining_elements)
+            if count == 100:
+                raise Exception("Illegal file list received as response to STATUS?file_list Request")
+            file_list_raw_obj.seek(0)
 
-            # Read out the file info and figure out whether to schedule it
-            # for mirroring or not (file referenced by File ID + Version),
-            # if this file is:
-            #
-            # - being mirrored already (if it is queued): Skip.
-            #
-            # - available in the local cluster name space: Skip.
-            #
-            # - not already available in local cluster name space: Schedule it.
-            while (True):
-                nextLine = fo.readline()
-                if (nextLine == ""): break
-                if (nextLine.find("FileStatus AccessDate=") != -1):
-                    tmpFileObj = ngamsFileInfo.ngamsFileInfo().\
-                                 unpackXmlDoc(nextLine)
-                    fileKey = ngamsLib.genFileKey(None, tmpFileObj.getFileId(),
-                                                  tmpFileObj.getFileVersion())
+            # Read out the file info and figure out whether to schedule it for mirroring or not (file referenced by
+            # File ID + Version), if this file is:
+            # * being mirrored already (if it is queued): Skip
+            # * available in the local cluster name space: Skip
+            # * not already available in local cluster name space: Schedule it
+            while True:
+                next_line = file_list_raw_obj.readline()
+                if next_line == "":
+                    break
+                if next_line.find("FileStatus AccessDate=") != -1:
+                    tmp_file_obj = ngamsFileInfo.ngamsFileInfo().unpackXmlDoc(next_line)
+                    file_key = ngamsLib.genFileKey(None, tmp_file_obj.get_file_id(), tmp_file_obj.getFileVersion())
                     # Entry found in the
-                    # - Mirroring DBM Queue?
-                    # - Error DBM Queue?
-                    # - Completed DBM Queue?
+                    #   * Mirroring DBM Queue?
+                    #   * Error DBM Queue?
+                    #   * Completed DBM Queue?
                     # Are there enough local copies in the cluster name space?
-                    msg = "Checking whether to schedule file: %s/%d for " +\
-                          "mirroring ..."
-                    logger.debug(msg, tmpFileObj.getFileId(),
-                                   tmpFileObj.getFileVersion())
-                    if (srvObj._mirQueueDbm.hasKey(fileKey)):
+                    logger.debug("Checking whether to schedule file: %s/%d for mirroring ...",
+                                 tmp_file_obj.get_file_id(), tmp_file_obj.getFileVersion())
+                    if ngams_server._mirQueueDbm.hasKey(file_key):
                         continue
-                    elif (srvObj._errQueueDbm.hasKey(fileKey)):
+                    elif ngams_server._errQueueDbm.hasKey(file_key):
                         continue
-                    elif (srvObj._complQueueDbm.hasKey(fileKey)):
+                    elif ngams_server._complQueueDbm.hasKey(file_key):
                         continue
                     else:
-                        # Check if the file is available in the name space of
-                        # this cluster. If not, schedule it.
-                        if (not clusterFilesDbm.hasKey(fileKey)):
+                        # Check if the file is available in the name space of this cluster. If not, schedule it.
+                        if not cluster_files_dbm.hasKey(file_key):
                             # The data object is not available, schedule it!
-                            srvListIdDb = srvObj.getSrvListDic()\
-                                          [mirSrcObj.getServerList()]
-                            scheduleMirReq(srvObj, hostId,
-                                           tmpFileObj.getFileId(),
-                                           tmpFileObj.getFileVersion(),
-                                           tmpFileObj.getIngestionDate(),
-                                           srvListIdDb, nextLine)
-
-            # Stop if there are no more elements to read out.
-            if (remainingEls == 0): break
-
+                            server_list_id_db = ngams_server.getSrvListDic()[mirror_source.getServerList()]
+                            schedule_mirror_request(ngams_server, host_id, tmp_file_obj.get_file_id(),
+                                                    tmp_file_obj.getFileVersion(), tmp_file_obj.getIngestionDate(),
+                                                    server_list_id_db, next_line)
+            # Stop if there are no more elements to read out
+            if remaining_elements == 0:
+                break
     except Exception as e:
-        msg = "Error retrieving file list. Error: %s"
-        raise Exception(msg % str(e))
+        raise Exception("Error retrieving file list. Error: %s" % str(e))
 
 
-def checkSourceArchives(srvObj):
+def check_source_archives(ngams_server):
     """
-    Check the source archives to see if data is available for mirroring.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    Returns:    Void.
+    Check the source archives to see if data is available for mirroring
+    :param ngams_server: Reference to server object (ngamsServer)
     """
-    # Dump the information for all files managed by this cluster.
-    clusterName = srvObj.getDb().getClusterNameFromHostId(srvObj.getHostId())
-    clusterFilesDbmName = "%s/%s_%s" %\
-                          (ngamsHighLevelLib.\
-                           getNgasChacheDir(srvObj.getCfg()),
-                           NGAMS_MIR_CLUSTER_FILE_DBM, clusterName)
-    clusterFilesDbmName = os.path.normpath(clusterFilesDbmName)
-    # Dump information about files registered in this cluster.
-    # Use the file key as key in the DBM, count occurrences of each file.
-    clusterFilesDbmName = srvObj.getDb().\
-                          dumpFileInfoCluster(clusterName,
-                                              clusterFilesDbmName,
-                                              useFileKey = True,
-                                              count = True)
+    # Dump the information for all files managed by this cluster
+    cluster_name = ngams_server.getDb().getClusterNameFromHostId(ngams_server.getHostId())
+    cluster_files_dbm_name = "%s/%s_%s" % (ngamsHighLevelLib.getNgasChacheDir(ngams_server.getCfg()),
+                                           NGAMS_MIR_CLUSTER_FILE_DBM, cluster_name)
+    cluster_files_dbm_name = os.path.normpath(cluster_files_dbm_name)
 
-    # Loop over the various Mirroring Source Archives specified in the
-    # configuration.
-    for mirSrcObj in srvObj.getCfg().getMirroringSrcList():
-        dbmMirSrcObj = srvObj._srcArchInfoDbm.get(mirSrcObj.getId())
+    # Dump information about files registered in this cluster
+    # Use the file key as key in the DBM, count occurrences of each file
+    cluster_files_dbm_name = ngams_server.getDb().dumpFileInfoCluster(cluster_name, cluster_files_dbm_name,
+                                                                      useFileKey=True, count=True)
 
-        # Figure out if a partial or complete sync should be done for this
-        # mirroring source.
-        timeNow = time.time()
-        doPartialSync = False
-        doComplSync = False
-        if (mirSrcObj.getCompleteSyncList()):
-            # OK, it is specified to do complete sync's in the configuration.
-            timeNowTag = "%s_TIME_NOW" % toiso8601(timeNow, fmt=FMT_TIME_ONLY_NOMSEC)
-            # Find the last time stamp compared to now.
-            tmpComplSyncList = copy.deepcopy(mirSrcObj.getCompleteSyncList())
-            tmpComplSyncList.append(timeNowTag)
-            tmpComplSyncList.sort()
-            timeNowIdx = tmpComplSyncList.index(timeNowTag)
-            # Get the closest sync. time handle (from the configuration)
-            # compared to the present time.
-            relevantSyncTime = tmpComplSyncList[timeNowIdx - 1]
-            lastComplSync =\
-                          dbmMirSrcObj.\
-                          getLastCompleteSyncDic()[relevantSyncTime]
-            if (not lastComplSync):
-                # The sync time for that cfg. sync entry is None -> no sync
-                # yet done for that sync time, just do it.
-                doComplSync = True
+    # Loop over the various Mirroring Source Archives specified in the configuration
+    for mirror_source_obj in ngams_server.getCfg().getMirroringSrcList():
+        dbm_mirror_source_obj = ngams_server._srcArchInfoDbm.get(mirror_source_obj.getId())
+
+        # Figure out if a partial or complete sync should be done for this mirroring source
+        time_now = time.time()
+        do_partial_sync = False
+        do_complete_sync = False
+        if mirror_source_obj.getCompleteSyncList():
+            # OK, it is specified to do complete sync's in the configuration
+            time_now_tag = "%s_TIME_NOW" % toiso8601(time_now, fmt=FMT_TIME_ONLY_NOMSEC)
+            # Find the last time stamp compared to now
+            tmp_complete_sync_list = copy.deepcopy(mirror_source_obj.getCompleteSyncList())
+            tmp_complete_sync_list.append(time_now_tag)
+            tmp_complete_sync_list.sort()
+            time_now_idx = tmp_complete_sync_list.index(time_now_tag)
+            # Get the closest sync. time handle (from the configuration) compared to the present time
+            relevant_sync_time = tmp_complete_sync_list[time_now_idx - 1]
+            last_complete_sync = dbm_mirror_source_obj.getLastCompleteSyncDic()[relevant_sync_time]
+            if not last_complete_sync:
+                # The sync time for that cfg sync entry is None -> no sync yet done for that sync time, just do it
+                do_complete_sync = True
             else:
-                # Check if a complete sync for the relevant time was done
-                # within the last 24 hours.
-                dateNow = timeNowTag.split("_")[0]
-                dateLastSync = lastComplSync.split("T")[0]
-                if (dateNow > dateLastSync): doComplSync = True
+                # Check if a complete sync for the relevant time was done within the last 24 hours
+                date_now = time_now_tag.split("_")[0]
+                date_last_sync = last_complete_sync.split("T")[0]
+                if date_now > date_last_sync:
+                    do_complete_sync = True
 
-        # Figure out if a partial sync should be done if not a complete sync
-        # should be carried out.
-        if (not doComplSync):
-            lastPartialSyncSecs = dbmMirSrcObj.getLastSyncTime()
-            if ((timeNow - lastPartialSyncSecs) >= dbmMirSrcObj.getPeriod()):
-                doPartialSync = True
+        # Figure out if a partial sync should be done if not a complete sync should be carried out
+        if not do_complete_sync:
+            last_partial_sync_secs = dbm_mirror_source_obj.getLastSyncTime()
+            if (time_now - last_partial_sync_secs) >= dbm_mirror_source_obj.getPeriod():
+                do_partial_sync = True
 
-        # If no synchronization to be done for this source, continue to the
-        # next mirroring source.
-        if ((not doPartialSync) and (not doComplSync)): continue
+        # If no synchronization to be done for this source, continue to the next mirroring source
+        if not do_partial_sync and not do_complete_sync:
+            continue
 
-        # Complete sync: Don't specify a lower limit ingestion date.
-        # Partial sync:  Specify lower limit ingestion date.
-        # TODO: For now only ingestion date is supported as selection criteria.
-        maxEls = 100000
-        statusCmdPars = [[NGAMS_HTTP_PAR_FILE_LIST, 1],
-                         [NGAMS_HTTP_PAR_UNIQUE, 1],
-                         [NGAMS_HTTP_PAR_MAX_ELS, maxEls]]
-        if (doPartialSync):
-            statusCmdPars.append([NGAMS_HTTP_PAR_FROM_ING_DATE,
-                                  toiso8601(dbmMirSrcObj.getLastSyncTime())])
+        # Complete sync: Don't specify a lower limit ingestion date
+        # Partial sync:  Specify lower limit ingestion date
+        # TODO: For now only ingestion date is supported as selection criteria
+        max_elements = 100000
+        status_cmd_pars = [[NGAMS_HTTP_PAR_FILE_LIST, 1],
+                           [NGAMS_HTTP_PAR_UNIQUE, 1],
+                           [NGAMS_HTTP_PAR_MAX_ELS, max_elements]]
+        if do_partial_sync:
+            status_cmd_pars.append([NGAMS_HTTP_PAR_FROM_ING_DATE, toiso8601(dbm_mirror_source_obj.getLastSyncTime())])
 
         # Go through the list, we shuffle it to get some kind of load balancing
-        srvListIndexes = range(len(srvObj.getSrvListDic()[mirSrcObj.getId()]))
-        random.shuffle(srvListIndexes)
-        for srvIdx in srvListIndexes:
-            nextSrv, nextPort = srvObj.\
-                                getSrvListDic()[mirSrcObj.getId()][srvIdx].\
-                                split(":")
-            nextPort = int(nextPort)
-            msg = "Sending STATUS/file_list request to Source Archive: %s. " +\
-                  "Node: %s/%d"
-            if (doComplSync):
+        server_list_indexes = range(len(ngams_server.getSrvListDic()[mirror_source_obj.getId()]))
+        random.shuffle(server_list_indexes)
+        for server_index in server_list_indexes:
+            next_server, next_port = ngams_server.getSrvListDic()[mirror_source_obj.getId()][server_index].split(":")
+            next_port = int(next_port)
+            msg = "Sending STATUS/file_list request to Source Archive: %s. Node: %s/%d"
+            if do_complete_sync:
                 msg += ". Complete synchronization"
             else:
-                msg += ". Partial synchronization from date: %s" %\
-                       toiso8601(dbmMirSrcObj.getLastSyncTime())
-            logger.debug(msg, mirSrcObj.getId(), nextSrv, nextPort)
+                msg += ". Partial synchronization from date: %s" % toiso8601(dbm_mirror_source_obj.getLastSyncTime())
+            logger.debug(msg, mirror_source_obj.getId(), next_server, next_port)
             try:
-                retrieveFileList(srvObj, mirSrcObj, nextSrv, nextPort,
-                                 statusCmdPars, clusterFilesDbmName)
-                # The retrieval of the file list was successful, we don't need
-                # to contacting others of the specified contact nodes.
+                retrieve_file_list(ngams_server, mirror_source_obj, next_server, next_port, status_cmd_pars,
+                                   cluster_files_dbm_name)
+                # The retrieval of the file list was successful, we don't need to contacting others of the
+                # specified contact nodes
                 break
             except Exception as e:
-                # Create log entry in case it was not possible to communicate
-                # to this Mirroring Source Archive. Continue to the next
-                # Mirroring Source Archive in that case.
-                msg = "Error sending STATUS/file_list to Mirroring Source " +\
-                      "Archive with ID: %s (%s:%d). Error: %s"
-                logger.error(msg, mirSrcObj.getId(), nextSrv, nextPort, str(e))
-                # Try the next contact node specified in the cfg.
+                # Create log entry in case it was not possible to communicate to this Mirroring Source Archive.
+                # Continue to the next Mirroring Source Archive in that case.
+                logger.error("Error sending STATUS/file_list to Mirroring Source Archive with ID: %s (%s:%d). " 
+                             "Error: %s", mirror_source_obj.getId(), next_server, next_port, str(e))
+                # Try the next contact node specified in the configuration
                 continue
 
-        # Register the times for the last partial or complete sync.
-        if (doComplSync):
-            dbmMirSrcObj.\
-                           getLastCompleteSyncDic()[relevantSyncTime] =\
-                           toiso8601(timeNow, local=True)
-            # Fair enough to consider that a partial sync been done when a
-            # complete sync has been carried out.
-            dbmMirSrcObj.setLastSyncTime(timeNow)
-        elif (doPartialSync):
-            dbmMirSrcObj.setLastSyncTime(timeNow)
+        # Register the times for the last partial or complete sync
+        if do_complete_sync:
+            dbm_mirror_source_obj.getLastCompleteSyncDic()[relevant_sync_time] = toiso8601(time_now, local=True)
+            # Fair enough to consider that a partial sync been done when a complete sync has been carried out
+            dbm_mirror_source_obj.setLastSyncTime(time_now)
+        elif do_partial_sync:
+            dbm_mirror_source_obj.setLastSyncTime(time_now)
 
-        # Store the updated Source Archive Object back into the Source
-        # Archive DBM.
-        srvObj._srcArchInfoDbm.add(mirSrcObj.getId(), dbmMirSrcObj).sync()
+        # Store the updated Source Archive Object back into the Source Archive DBM
+        ngams_server._srcArchInfoDbm.add(mirror_source_obj.getId(), dbm_mirror_source_obj).sync()
 
-    # Signal to the Mirroring Threads that there might be new Mirroring
-    # Requests to handle.
-    srvObj.triggerMirThreads()
+    # Signal to the Mirroring Threads that there might be new Mirroring Requests to handle
+    ngams_server.triggerMirThreads()
 
 
-def checkErrorQueue(srvObj):
+def check_error_queue(ngams_server):
     """
-    Check the Error Queue for failing Mirroring Requests to reschedule into
-    the internal DB Mirroring Queue.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    Returns:    Void.
+    Check the Error Queue for failing Mirroring Requests to reschedule into the internal DB Mirroring Queue
+    :param ngams_server: Reference to server object (ngamsServer)
     """
     # Go through the list of entries in the Error Queue. Handle as follows:
-    #
-    # - For entries marked as Error/Reschedule:
-    #
-    #   - If the time since last activity time is larger than the
-    #     ErrorRetryPeriod specified in the configuration, put these back into
-    #     the Mirroring Queue.
-    #
-    #   - If the ErrorRetryTimeOut has expired, leave the entry in the queue
-    #     for the reporting.
-    #
-    # - For entries marked as Error/Abandon: Leave these in the queue to be
-    #   handled later by the reporting.
+    # * For entries marked as Error/Reschedule:
+    #   * If the time since last activity time is larger than the ErrorRetryPeriod specified in the configuration, put
+    #     these back into the Mirroring Queue.
+    #   * If the ErrorRetryTimeOut has expired, leave the entry in the queue for the reporting.
+    # * For entries marked as Error/Abandon: Leave these in the queue to be handled later by the reporting.
 
-    # We create a snapshot of the keys in the Error DBM, so that we can
-    # pass through these without interferring with other activities, and
-    # to avoid creating a maybe huge list in memory.
-    dbmName = "%s/%s_%s" %\
-              (ngamsHighLevelLib.getNgasChacheDir(srvObj.getCfg()),
-               "NGAMS_MIR_ERR_QUEUE_KEYS_DBM",
-               srvObj.getHostInfoObj().getClusterName())
-    dbmName = dumpKeysQueue(srvObj, srvObj._errQueueDbm,
-                            srvObj._errQueueDbmSem, dbmName)
-    errQueueKeysDbm = ngamsDbm.ngamsDbm(dbmName, cleanUpOnDestr = True)
-    errQueueKeysDbm.initKeyPtr()
-    while (True):
-        nextKey, data = errQueueKeysDbm.getNext()
-        if (not nextKey): break
+    # We create a snapshot of the keys in the Error DBM, so that we can pass through these without interfering with
+    # other activities, and to avoid creating a maybe huge list in memory.
+    dbm_name = "%s/%s_%s" % (ngamsHighLevelLib.getNgasChacheDir(ngams_server.getCfg()), "NGAMS_MIR_ERR_QUEUE_KEYS_DBM",
+                             ngams_server.getHostInfoObj().getClusterName())
+    dbm_name = dump_keys_queue(ngams_server._errQueueDbm, ngams_server._errQueueDbmSem, dbm_name)
+    error_queue_keys_dbm = ngamsDbm.ngamsDbm(dbm_name, cleanUpOnDestr=True)
+    error_queue_keys_dbm.initKeyPtr()
+    while True:
+        next_key, data = error_queue_keys_dbm.getNext()
+        if not next_key:
+            break
         try:
-            mirReqObj = srvObj._errQueueDbm.get(nextKey)
-        except:
-            # Maybe this entry was removed by the reporting, ignore, continue
-            # to the next entry.
+            mirror_request_obj = ngams_server._errQueueDbm.get(next_key)
+        except Exception:
+            # Maybe this entry was removed by the reporting, ignore, continue to the next entry
             continue
-        if (mirReqObj.getStatusAsNo() ==
-            ngamsMirroringRequest.NGAMS_MIR_REQ_STAT_ERR_RETRY_NO):
-            # If the time since last activity is longer than ErrorRetryPeriod
-            # reschedule the request into the Mirroring Queue.
-            timeNow = time.time()
-            if ((timeNow - mirReqObj.getLastActivityTime()) >
-                srvObj.getCfg().getMirroringErrorRetryPeriod()):
+        if mirror_request_obj.getStatusAsNo() == NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_ERR_RETRY_NO:
+            # If the time since last activity is longer than ErrorRetryPeriod reschedule the request into the
+            # Mirroring Queue
+            time_now = time.time()
+            if (time_now - mirror_request_obj.getLastActivityTime()) > \
+                    ngams_server.getCfg().getMirroringErrorRetryPeriod():
                 try:
-                    mirReqObj = popEntryQueue(srvObj, mirReqObj,
-                                              srvObj._errQueueDbm,
-                                              srvObj._errQueueDbmSem)
-                    addEntryMirQueue(srvObj, mirReqObj)
+                    mirror_request_obj = pop_entry_queue(mirror_request_obj, ngams_server._errQueueDbm,
+                                                         ngams_server._errQueueDbmSem)
+                    add_entry_mirror_queue(ngams_server, mirror_request_obj)
                 except Exception as e:
-                    msg = "Error moving Mirroring Request from Error DBM " +\
-                          "Queue to the Mirroring DBM Queue: %s"
-                    logger.error(msg, str(e))
+                    logger.error("Error moving Mirroring Request from Error DBM Queue to the Mirroring DBM Queue: %s",
+                                 str(e))
         else:
-            # NGAMS_MIR_REQ_STAT_ERR_ABANDON_NO: Do nothing.
+            # NGAMS_MIR_REQ_STAT_ERR_ABANDON_NO: Do nothing
             pass
+    ngams_server.triggerMirThreads()
 
-    srvObj.triggerMirThreads()
 
-
-def generateReport(srvObj):
+def generate_report(ngams_server):
     """
     Check the queues and report the Mirroring Requests in the
-
-      - Mirroring Queue.
-      - Completed Queue.
-      - Error Queue.
-
+        * Mirroring Queue
+        * Completed Queue
+        * Error Queue
     A summary report and a detailed report is generated.
-
-    srvObj:     Reference to server object (ngamsServer).
-
-    Returns:    Void.
+    :param ngams_server: Reference to server object (ngamsServer)
     """
-    reportHdr = "Date:         %s\n" +\
-                "Control Node: %s\n\n"
-    reportHdr = reportHdr % (toiso8601(), srvObj.getHostId())
-    summary   = "NGAS MIRRORING - SUMMARY REPORT\n\n" + reportHdr
+    report_header = "Date:         %s\n" +\
+                    "Control Node: %s\n\n"
+    report_header = report_header % (toiso8601(), ngams_server.getHostId())
+    summary = "NGAS MIRRORING - SUMMARY REPORT\n\n" + report_header
 
-    # Go through the various queue DBMs.
-    dbmName = "%s/%s_%s" %\
-              (ngamsHighLevelLib.getNgasChacheDir(srvObj.getCfg()),
-               "NGAMS_MIR_REPORINTG_QUEUE_KEYS_DBM",
-               srvObj.getHostInfoObj().getClusterName())
+    # Go through the various queue DBMs
+    dbm_name = "%s/%s_%s" % (ngamsHighLevelLib.getNgasChacheDir(ngams_server.getCfg()),
+                             "NGAMS_MIR_REPORINTG_QUEUE_KEYS_DBM",
+                             ngams_server.getHostInfoObj().getClusterName())
 
-    # Go through Completed Queue.
-    dbmName = dumpKeysQueue(srvObj, srvObj._complQueueDbm,
-                            srvObj._complQueueDbmSem, dbmName)
-    complQueueKeysDbm = ngamsDbm.ngamsDbm(dbmName, cleanUpOnDestr = True)
-    complQueueKeysDbm.initKeyPtr()
-    completedCount = 0
-    while (True):
-        nextKey, mirReqObj = complQueueKeysDbm.getNext()
-        if (not nextKey): break
+    # Go through Completed Queue
+    dbm_name = dump_keys_queue(ngams_server._complQueueDbm, ngams_server._complQueueDbmSem, dbm_name)
+    completed_queue_keys_dbm = ngamsDbm.ngamsDbm(dbm_name, cleanUpOnDestr=True)
+    completed_queue_keys_dbm.initKeyPtr()
+    completed_count = 0
+
+    while True:
+        next_key, mirror_request = completed_queue_keys_dbm.getNext()
+        if not next_key:
+            break
         try:
-            mirReqObj = popEntryQueue(srvObj, mirReqObj,
-                                      srvObj._complQueueDbm,
-                                      srvObj._complQueueDbmSem)
-            completedCount += 1
+            pop_entry_queue(mirror_request, ngams_server._complQueueDbm, ngams_server._complQueueDbmSem)
+            completed_count += 1
         except Exception as e:
-            msg = "Error popping Mirroring Request from the Completed " +\
-                  "DBM Queue: %s"
-            logger.error(msg, str(e))
-    summary += "Completed Requests:    %d\n" % completedCount
+            logger.error("Error popping Mirroring Request from the Completed DBM Queue: %s", str(e))
 
-    # Go through Error Queue.
-    dbmName = dumpKeysQueue(srvObj, srvObj._errQueueDbm,
-                            srvObj._errQueueDbmSem, dbmName)
-    errRetryCount = 0
-    errTimeoutCount = 0
-    errAbandonCount = 0
-    errQueueKeysDbm = ngamsDbm.ngamsDbm(dbmName, cleanUpOnDestr = True)
-    errQueueKeysDbm.initKeyPtr()
-    while (True):
-        nextKey, mirReqObj = errQueueKeysDbm.getNext()
-        if (not nextKey): break
-        if (mirReqObj.getStatusAsNo() ==
-            ngamsMirroringRequest.NGAMS_MIR_REQ_STAT_ERR_ABANDON):
+    summary += "Completed Requests:    %d\n" % completed_count
+
+    # Go through Error Queue
+    dbm_name = dump_keys_queue(ngams_server._errQueueDbm, ngams_server._errQueueDbmSem, dbm_name)
+    error_retry_count = 0
+    error_timeout_count = 0
+    error_abandon_count = 0
+    error_queue_keys_dbm = ngamsDbm.ngamsDbm(dbm_name, cleanUpOnDestr=True)
+    error_queue_keys_dbm.initKeyPtr()
+
+    while True:
+        next_key, mirror_request = error_queue_keys_dbm.getNext()
+        if not next_key:
+            break
+        if mirror_request.getStatusAsNo() == NgamsMirroringRequest.NGAMS_MIR_REQ_STAT_ERR_ABANDON:
             try:
-                mirReqObj = popEntryQueue(srvObj, mirReqObj,
-                                          srvObj._errQueueDbm,
-                                          srvObj._errQueueDbmSem)
-                errAbandonCount += 1
+                pop_entry_queue(mirror_request, ngams_server._errQueueDbm, ngams_server._errQueueDbmSem)
+                error_abandon_count += 1
             except Exception as e:
-                msg = "Error popping Mirroring Request from Error DBM " +\
-                      "Queue: %s"
-                logger.error(msg, str(e))
-        elif ((time.time() - mirReqObj.getSchedulingTime()) >
-              srvObj.getCfg().getMirroringErrorRetryPeriod()):
+                logger.error("Error popping Mirroring Request from Error DBM Queue: %s", str(e))
+        elif (time.time() - mirror_request.getSchedulingTime()) > ngams_server.getCfg().getMirroringErrorRetryPeriod():
             try:
-                mirReqObj = popEntryQueue(srvObj, mirReqObj,
-                                          srvObj._errQueueDbm,
-                                          srvObj._errQueueDbmSem)
-                errTimeoutCount += 1
+                pop_entry_queue(mirror_request, ngams_server._errQueueDbm, ngams_server._errQueueDbmSem)
+                error_timeout_count += 1
             except Exception as e:
-                msg = "Error popping Mirroring Request from Error DBM " +\
-                      "Queue: %s"
-                logger.error(msg, str(e))
+                logger.error("Error popping Mirroring Request from Error DBM Queue: %s", str(e))
         else:
-            errRetryCount += 1
-    summary += "Error Request/Retry:   %d\n" % errRetryCount
-    summary += "Error Request/Timeout: %d\n" % errTimeoutCount
-    summary += "Error Request/Abandon: %d\n" % errAbandonCount
+            error_retry_count += 1
+    summary += "Error Request/Retry:   %d\n" % error_retry_count
+    summary += "Error Request/Timeout: %d\n" % error_timeout_count
+    summary += "Error Request/Abandon: %d\n" % error_abandon_count
 
-    # Go through Mirroring Queue.
-    dbmName = dumpKeysQueue(srvObj, srvObj._mirQueueDbm,
-                            srvObj._mirQueueDbmSem, dbmName)
-    mirQueueKeysDbm = ngamsDbm.ngamsDbm(dbmName, cleanUpOnDestr = True)
-    mirQueueKeysDbm.initKeyPtr()
-    mirQueueCount = 0
-    while (True):
-        nextKey, mirReqObj = mirQueueKeysDbm.getNext()
-        if (not nextKey): break
-        mirQueueCount += 1
-    summary += "Mirroring Queue:    %d\n" % mirQueueCount
+    # Go through Mirroring Queue
+    dbm_name = dump_keys_queue(ngams_server._mirQueueDbm, ngams_server._mirQueueDbmSem, dbm_name)
+    mirror_queue_keys_dbm = ngamsDbm.ngamsDbm(dbm_name, cleanUpOnDestr=True)
+    mirror_queue_keys_dbm.initKeyPtr()
+    mirror_queue_count = 0
 
-    # Submit report to the specified recipients.
-    if (srvObj.getCfg().getMirroringReportRecipients()):
-        repRecipients = str(srvObj.getCfg().getMirroringReportRecipients()).\
-                        strip()
-        if (not repRecipients): return
+    while True:
+        next_key, mirror_request = mirror_queue_keys_dbm.getNext()
+        if not next_key:
+            break
+        mirror_queue_count += 1
+    summary += "Mirroring Queue:    %d\n" % mirror_queue_count
+
+    # Submit report to the specified recipients
+    if ngams_server.getCfg().getMirroringReportRecipients():
+        report_recipients = str(ngams_server.getCfg().getMirroringReportRecipients()).strip()
+        if not report_recipients:
+            return
         subject = "NGAS MIRRORING SERVICE STATUS REPORT"
-        for recipient in repRecipients.split(","):
-            ngamsHighLevelLib.sendEmail(srvObj.getCfg(),
-                                        subject, [recipient],
-                                        srvObj.getCfg().getSender(), summary,
-                                        "text/plain")
+        for recipient in report_recipients.split(","):
+            ngamsHighLevelLib.sendEmail(ngams_server.getCfg(), subject, [recipient], ngams_server.getCfg().getSender(),
+                                        summary, "text/plain")
 
-def cleanUpMirroring(srvObj):
-    host = get_full_qualified_name(srvObj)
-    logger.debug("cleaning up mirroring tasks for ngas node: %s", host)
-    sql = "update ngas_mirroring_bookkeeping set status = 'ABORTED', staging_file = null where status = 'READY' and target_host = {0}"
-    srvObj.getDb().query2(sql, args=(host,))
+
+def clean_up_mirroring(ngams_server):
+    host = get_fully_qualified_domain_name(ngams_server)
+    logger.debug("Cleaning up mirroring tasks for NGAS node: %s", host)
+    sql = "update ngas_mirroring_bookkeeping set status = 'ABORTED', staging_file = null " \
+          "where status = 'READY' and target_host = {0}"
+    ngams_server.getDb().query2(sql, args=(host,))
     sql = "update ngas_mirroring_bookkeeping set status = 'TORESUME' where status = 'FETCHING' and target_host = {0}"
-    srvObj.getDb().query2(sql, args=(host,))
+    ngams_server.getDb().query2(sql, args=(host,))
 
-def get_full_qualified_name(srvObj):
+
+def get_fully_qualified_domain_name(ngams_server):
     """
     Get full qualified server name for the input NGAS server object
-
-    INPUT:
-        srvObj  ngamsServer, Reference to NG/AMS server class object
-
-    RETURNS:
-        fqdn    string, full qualified host name (host name + domain + port)
+    :param ngams_server: ngamsServer, Reference to NG/AMS server class object
+    :return: string, full qualified host name (host name + domain + port)
     """
-
     # Get hots_id, domain and port using ngamsLib functions
-    host_id = srvObj.getHostId()
+    host_id = ngams_server.getHostId()
     domain = ngamsLib.getDomain()
-    port = str(srvObj.getCfg().getPortNo())
+    port = str(ngams_server.getCfg().getPortNo())
     # Concatenate all elements to construct full qualified name
     # Notice that host_id may contain port number
     fqdn = (host_id.rsplit(":"))[0] + "." + domain + ":" + port
-
-    # Return full qualified server name
     return fqdn
 
 
-def mirControlThread(srvObj, stopEvt):
+def get_mirroring_sleep_time(ngams_server):
     """
-    The Mirroring Control Thread runs periodically when the NG/AMS Server is
-    Online (if enabled) to synchronize the data holding of the local NGAS
-    Cluster against a set of remote NGAS Clusters.
-
-    srvObj:      Reference to server object (ngamsServer).
-
-    dummy:       Needed by the thread handling ...
-
-    Returns:     Void.
+    Get the sleep time parameter value from ngas_cfg_pars DB table
     """
-    # Alma Mirroring Service
-    if (srvObj.getCfg().getVal("Mirroring[1].AlmaMirroring")):
+    sql = "select cfg_val from ngas_cfg_pars where cfg_par = 'sleepTime'"
 
-        timeout = 6 * 3600
-        sleepTime = getMirroringSleepTime(srvObj)
+    logger.debug("Executing SQL query to get mirroring sleep time: %s", sql)
+    sleep_time = float(ngams_server.getDb().query2(sql)[0][0])
 
-        logger.info("ALMA Mirroring Control Thread cleaning up from previous state")
-        cleanUpMirroring(srvObj)
+    logger.debug("Mirroring sleep time value is %.3f", sleep_time)
+    return sleep_time
 
-        logger.info("ALMA Mirroring Control Thread entering main server loop")
-        while (True):
 
-            # Incapsulate this whole block to avoid that the thread dies in
+def mirror_control_thread(ngams_server, stop_event):
+    """
+    The Mirroring Control Thread runs periodically when the NG/AMS Server is Online (if enabled) to synchronize the
+    data holding of the local NGAS Cluster against a set of remote NGAS Clusters.
+    :param ngams_server: Reference to server object (ngamsServer)
+    :param stop_event: Stop event
+    """
+    if ngams_server.getCfg().getVal("Mirroring[1].AlmaMirroring"):
+        logger.info("ALMA mirroring control thread cleaning up from previous state")
+        clean_up_mirroring(ngams_server)
+
+        logger.info("ALMA mirroring control thread entering main server loop")
+        while True:
+            # Encapsulate this whole block to avoid that the thread dies in case a problem occurs,
+            # like e.g. a problem with the DB connection
             try:
-                checkStopMirControlThread(stopEvt)
+                check_stop_mirror_control_thread(stop_event)
                 logger.debug("ALMA Mirroring Control Thread starting next iteration ...")
 
                 # Update mirroring book keeping table
-                # TODO: handle the response, there's no information whatsoever
-                # if things went fine or not
+                # TODO: handle the response, there's no information whatsoever if things went fine or not
                 logger.debug("ALMA Mirroring Control Thread updating book keeping table ...")
-                local_server_contact_ip = get_contact_ip(srvObj.getCfg())
-                ngamsHttpUtils.httpGet(local_server_contact_ip, srvObj.portNo, 'MIRRTABLE', timeout=timeout)
+                local_server_contact_ip = get_contact_ip(ngams_server.getCfg())
+                timeout = 6 * 3600
+                ngamsHttpUtils.httpGet(local_server_contact_ip, ngams_server.portNo, 'MIRRTABLE', timeout=timeout)
 
-                # Sleep to let Janitor Thread and DCC do their tasks
-                # always reload from DB to allow for updates without restarting the server
-                sleepTime = getMirroringSleepTime(srvObj)
-                logger.info("ALMA Mirroring Control Thread sleeping for %.3f [s]", sleepTime)
-                suspend(stopEvt, sleepTime)
-
+                # Sleep to let Janitor Thread and Data Check do their tasks always reload from DB to allow for updates
+                # without restarting the server
+                sleep_time = get_mirroring_sleep_time(ngams_server)
+                logger.info("ALMA mirroring control thread sleeping for %.3f [s]", sleep_time)
+                suspend(stop_event, sleep_time)
             except Exception as e:
-                if (str(e).find(NGAMS_MIR_CONTROL_THR_STOP) != -1):
+                if str(e).find(NGAMS_MIR_CONTROL_THR_STOP) != -1:
                     return
-                errMsg = "Error occurred during execution of the ALMA Mirroring " +\
-                         "Control Thread"
-                logger.exception(errMsg)
-                # We make a small wait here to avoid that the process tries
-                # too often to carry out the tasks that failed.
-                if stopEvt.wait(5.0):
+                logger.exception("Error occurred during execution of the ALMA mirroring control thread")
+                # We make a small wait here to avoid that the process tries too often to carry out tasks that failed
+                if stop_event.wait(5.0):
                     return
-
-    # Generic Mirroring service
     else:
-        # Initialize the mirroring service.
-        initMirroring(srvObj)
+        # Generic Mirroring service
+        initialise_mirroring(ngams_server)
 
-        # Start the Mirroring Threads.
-        startMirroringThreads(srvObj, stopEvt)
+        # Start the Mirroring Threads
+        start_mirroring_threads(ngams_server, stop_event)
 
-        # Render the suspension time as the minimum time for checking a remote
-        # archive.
-        period = (24 * 3600)
-        for mirSrcObj in srvObj.getCfg().getMirroringSrcList():
-            tmpPeriod = float(mirSrcObj.getPeriod())
-            if (tmpPeriod < period): period = tmpPeriod
+        # Render the suspension time as the minimum time for checking a remote archive
+        period = 24 * 3600
+        for mirror_source_obj in ngams_server.getCfg().getMirroringSrcList():
+            tmp_period = float(mirror_source_obj.getPeriod())
+            if tmp_period < period:
+                period = tmp_period
 
         logger.debug("Mirroring Control Thread entering main server loop")
-        while (True):
-            startTime = time.time()
+        while True:
+            start_time = time.time()
 
-            # Incapsulate this whole block to avoid that the thread dies in
-            # case a problem occurs, like e.g. a problem with the DB connection.
+            # Encapsulate this whole block to avoid that the thread dies in case a problem occurs,
+            # like e.g. a problem with the DB connection
             try:
-                checkStopMirControlThread(stopEvt)
+                check_stop_mirror_control_thread(stop_event)
                 logger.debug("Mirroring Control Thread starting next iteration ...")
 
-                ###################################################################
-                # Business logic of Mirroring Control Thread
-                ###################################################################
-
-                # Check if there are new data objects in the specified source
-                # archives to mirror. While checking this the Mirroring Threads
-                # should be paused, since otherwise, inconsistencies may occurr
+                # Check if there are new data objects in the specified source archives to mirror. While checking
+                # this the Mirroring Threads should be paused, since otherwise, inconsistencies may occur
                 # (e.g. a file scheduled several times).
                 try:
-                    pauseMirThreads(srvObj, stopEvt)
-                    checkSourceArchives(srvObj)
+                    pause_mirror_threads(ngams_server, stop_event)
+                    check_source_archives(ngams_server)
                 except Exception as e:
-                    if (str(e).find(NGAMS_MIR_CONTROL_THR_STOP) != -1): raise
-                resumeMirThreads(srvObj, stopEvt)
+                    if str(e).find(NGAMS_MIR_CONTROL_THR_STOP) != -1:
+                        raise
+                resume_mirror_threads(ngams_server, stop_event)
 
-                # Check if there are entries in Error State, which should be
-                # resumed.
-                checkErrorQueue(srvObj)
+                # Check if there are entries in Error State, which should be resumed
+                check_error_queue(ngams_server)
 
-                # Check if there entries to be reported in the queues and generate
-                # the report(s).
-                generateReport(srvObj)
-                ###################################################################
+                # Check if there entries to be reported in the queues and generate the report(s)
+                generate_report(ngams_server)
 
-                ###################################################################
-                # Suspend the Mirroring Control Thread for a while.
-                ###################################################################
-                suspTime = (period - (time.time() - startTime))
-                if (suspTime < 1): suspTime = 1
-                logger.debug("Mirroring Control Thread executed - suspending for %s [s]",
-                      str(suspTime))
-
-                suspend(stopEvt, suspTime)
-
+                # Suspend the Mirroring Control Thread for a while
+                suspend_time = period - (time.time() - start_time)
+                if suspend_time < 1:
+                    suspend_time = 1
+                logger.debug("Mirroring control thread executed - suspending for %s [s]", str(suspend_time))
+                suspend(stop_event, suspend_time)
             except Exception as e:
-                if (str(e).find(NGAMS_MIR_CONTROL_THR_STOP) != -1):
+                if str(e).find(NGAMS_MIR_CONTROL_THR_STOP) != -1:
                     return
-                errMsg = "Error occurred during execution of the Mirroring " +\
-                         "Control Thread"
-                logger.exception(errMsg)
-                # We make a small wait here to avoid that the process tries
-                # too often to carry out the tasks that failed.
-                if stopEvt.wait(5.0):
+                error_message = "Error occurred during execution of the mirroring control thread"
+                logger.exception(error_message)
+                # We insert a short delay here to help avoid that the process tries too often to carry out the task
+                # that caused the mirroring process to fail
+                if stop_event.wait(5.0):
                     return
-
-
-def getMirroringSleepTime(srvObj):
-    query = "select cfg_val"
-    query += " from ngas_cfg_pars"
-    query += " where cfg_par = 'sleepTime'"
-
-    # Execute query
-    logger.debug("Executing SQL query to get mirroring sleep time: %s" % query)
-    sleepTime = float(srvObj.getDb().query2(query)[0][0])
-
-    # Log info
-    logger.debug("result is %.3f", sleepTime)
-    return sleepTime
-
-# EOF

--- a/src/ngamsServer/ngamsServer/ngamsServer.py
+++ b/src/ngamsServer/ngamsServer/ngamsServer.py
@@ -657,7 +657,7 @@ class ngamsServer(object):
 
         # Handling of the Mirroring Control Thread.
         self._mir_control_thread = utils.Task(ngamsMirroringControlThread.NGAMS_MIR_CONTROL_THR,
-                                              ngamsMirroringControlThread.mirControlThread)
+                                              ngamsMirroringControlThread.mirror_control_thread)
         self.__mirControlTrigger      = threading.Event()
         self._pauseMirThreads         = False
         self._mirThreadsPauseCount    = 0

--- a/test/plugins/test_dapi_mirroring.py
+++ b/test/plugins/test_dapi_mirroring.py
@@ -21,22 +21,22 @@
 #
 
 """
-This module contains the Test Suite for the ngamsSdmMultipart plugin.
+This module contains the Test Suite for the ngamsDAPIMirroring plugin.
 """
 
 import os
 
-from ngamsPlugIns import ngamsSdmMultipart
+from ngamsPlugIns import ngamsDAPIMirroring
 from test import ngamsTestLib
 
 
-class NgamsSdmMultipartTest(ngamsTestLib.ngamsTestSuite):
+class NgamsDAPIMirroringTest(ngamsTestLib.ngamsTestSuite):
 
     def test_specific_treatment(self):
         sample_file_name = "A002_X9896b4_X10f"
         sample_file_path = self.resource(os.path.join("src", sample_file_name))
 
-        file_id, file_name, file_type = ngamsSdmMultipart.specific_treatment(sample_file_path)
+        file_id, file_name, file_type = ngamsDAPIMirroring.specific_treatment(sample_file_path)
         self.assertEqual(file_id, "A002/X9896b4/X10f")
         self.assertEqual(file_name, "A002:X9896b4:X10f")
         self.assertEqual(file_type, "multipart/mixed")


### PR DESCRIPTION
I was working on the mirroring plugin. I decided to clean up some of the code by applying PEP8 style guidelines. I also fixed a couple of bugs. You can follow the changes in the commit log.
Sadly there are still no unit tests for mirroring because it is just too complicated. I would need to create two clusters with two database schemas with a database link between the schemas. This is not achievable with sqlite. The alternative would be to mock the methods but this would require a significant amount of work and I don't have the time to do this at the moment.