### PR TITLE
Fix file_version bug in ngamsSdmMultipart plugin

### DIFF
--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
@@ -128,11 +128,8 @@ def ngamsSdmMultipart(ngams_server, request_properties):
     if request_properties.hasHttpPar("file_id"):
         file_id = request_properties.getHttpPar("file_id")
 
-    file_version = request_properties.getHttpPar("file_version")
-
     logger.debug("SDM multipart plug-in processing request for file with URI %s, file_format=%s, file_id=%s, "
-                 "file_version=%s, final_filename=%s", request_properties.getFileUri(), file_format, file_id,
-                 file_version, final_filename)
+                 "final_filename=%s", request_properties.getFileUri(), file_format, file_id, final_filename)
 
     try:
         # Compression parameters


### PR DESCRIPTION
A small bug fix. I forgot to test this change properly before committing. Now I have a CI pipeline I can setup more tests to catch these type of bugs in the future.