### PR TITLE
Fix retrieve command issues

### DIFF
--- a/src/ngamsServer/ngamsServer/commands/retrieve.py
+++ b/src/ngamsServer/ngamsServer/commands/retrieve.py
@@ -305,7 +305,7 @@ def _handleCmdRetrieve(srvObj,
     # If the hosts in the cluster have their IP address set to '0.0.0.0' this
     # will break request. We need to construct the full host name instead.
     host_address = ipAddress
-    if host_address == "0.0.0.0" or not host_address or host_address is None:
+    if host_address == "0.0.0.0" or not host_address:
         host_address = ngamsFileUtils.get_fqdn(location, host, domain)
 
     if location == NGAMS_HOST_LOCAL:

--- a/src/ngamsServer/ngamsServer/ngamsFileUtils.py
+++ b/src/ngamsServer/ngamsServer/ngamsFileUtils.py
@@ -589,7 +589,7 @@ def quickFileLocate(srvObj,
         if host_id == srvObj.getHostId():
             location = NGAMS_HOST_LOCAL
         else:
-            location = NGAMS_HOST_REMOTE
+            location = NGAMS_HOST_CLUSTER
         return [location] + list(res[0])
 
     return (8 if not include_compression else 9) * (None,)

--- a/src/ngamsServer/ngamsServer/ngamsFileUtils.py
+++ b/src/ngamsServer/ngamsServer/ngamsFileUtils.py
@@ -131,16 +131,12 @@ def get_fqdn(location, host_id, domain):
     if "." in host_address:
         return host_address
 
-    if not domain or domain is None:
-        if location == NGAMS_HOST_LOCAL \
-            or location == NGAMS_HOST_CLUSTER \
-                or location == NGAMS_HOST_DOMAIN:
+    if not domain and location in (NGAMS_HOST_LOCAL, NGAMS_HOST_CLUSTER, NGAMS_HOST_DOMAIN):
             domain = ngamsLib.getDomain()
 
-    if len(host_address) > 0 \
-        and (domain is not None and len(domain) > 0):
+    if host_address and domain:
         return "{}.{}".format(host_address, domain)
-    elif len (host_address) > 0:
+    elif host_address:
         return "{}".format(host_address)
     else:
         return None

--- a/src/ngamsServer/ngamsServer/ngamsFileUtils.py
+++ b/src/ngamsServer/ngamsServer/ngamsFileUtils.py
@@ -114,6 +114,9 @@ def get_fqdn(location, host_id, domain):
     FQDN:           Fully Qualified Domain NAME (so far as possible)
 
     """
+    if host_id is None:
+        return None
+
     host_address = None
     # Does the host_id contain the port?
     if ":" in host_id:
@@ -134,9 +137,10 @@ def get_fqdn(location, host_id, domain):
                 or location == NGAMS_HOST_DOMAIN:
             domain = ngamsLib.getDomain()
 
-    if host_address is not None and domain is not None:
+    if len(host_address) > 0 \
+        and (domain is not None and len(domain) > 0):
         return "{}.{}".format(host_address, domain)
-    elif host_address is not None:
+    elif len (host_address) > 0:
         return "{}".format(host_address)
     else:
         return None

--- a/src/ngamsServer/ngamsServer/ngamsServer.py
+++ b/src/ngamsServer/ngamsServer/ngamsServer.py
@@ -2391,7 +2391,7 @@ def _parse_and_run(args, prog, server_class):
         larg = arg.lower()
         if larg in _lower:
             if larg != arg:
-                print("WARNING: case-insenstive command-line option names are "
+                print("WARNING: case insensitive command-line option names are "
                       "deprecated and will be removed in the future. To avoid this "
                       "message change '%s' by '%s'" % (arg, larg))
             modified_args.append(larg)

--- a/src/ngamsServer/ngamsServer/ngamsServer.py
+++ b/src/ngamsServer/ngamsServer/ngamsServer.py
@@ -437,11 +437,7 @@ class ngamsHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
     def remote_proxy_request(self, request, host, port, timeout=300):
         """Proxy the current request to remote host ``host``:``port``"""
-        if ':' in host:
-            url = 'http://{0}/{1}'.format(host, NGAMS_RETRIEVE_CMD)
-        else:
-            url = 'http://{0}:{1}/{2}'.format(host, port, NGAMS_RETRIEVE_CMD)
-
+        url = 'http://{0}:{1}/{2}'.format(host, port, NGAMS_RETRIEVE_CMD)
         logger.info("Proxying request for /%s to %s:%d", NGAMS_RETRIEVE_CMD,
                     host, port)
 

--- a/src/ngamsServer/ngamsServer/ngamsServer.py
+++ b/src/ngamsServer/ngamsServer/ngamsServer.py
@@ -437,8 +437,11 @@ class ngamsHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
     def remote_proxy_request(self, request, host, port, timeout=300):
         """Proxy the current request to remote host ``host``:``port``"""
+        if ':' in host:
+            url = 'http://{0}/{1}'.format(host, NGAMS_RETRIEVE_CMD)
+        else:
+            url = 'http://{0}:{1}/{2}'.format(host, port, NGAMS_RETRIEVE_CMD)
 
-        url = 'http://{0}:{1}/{2}'.format(host, port, NGAMS_RETRIEVE_CMD)
         logger.info("Proxying request for /%s to %s:%d", NGAMS_RETRIEVE_CMD,
                     host, port)
 

--- a/test/test_partner_sites.py
+++ b/test/test_partner_sites.py
@@ -67,7 +67,7 @@ class NgasPartnerSiteTest(ngamsTestSuite):
         host_address = ngamsFileUtils.get_fqdn(NGAMS_HOST_CLUSTER, "ngas", "example.com")
         self.assertEqual(host_address, "ngas.example.com")
         host_address = ngamsFileUtils.get_fqdn(NGAMS_HOST_CLUSTER, "ngas", None)
-        self.assertTrue(host_address.startswith("ngas."))
+        self.assertTrue(host_address.startswith("ngas"))
         host_address = ngamsFileUtils.get_fqdn(NGAMS_HOST_REMOTE, "ngas", "example.com")
         self.assertEqual(host_address, "ngas.example.com")
         host_address = ngamsFileUtils.get_fqdn(NGAMS_HOST_REMOTE, "ngas", None)

--- a/test/test_partner_sites.py
+++ b/test/test_partner_sites.py
@@ -67,7 +67,7 @@ class NgasPartnerSiteTest(ngamsTestSuite):
         host_address = ngamsFileUtils.get_fqdn(NGAMS_HOST_CLUSTER, "ngas", "example.com")
         self.assertEqual(host_address, "ngas.example.com")
         host_address = ngamsFileUtils.get_fqdn(NGAMS_HOST_CLUSTER, "ngas", None)
-        self.assertRegex(host_address, "^ngas\..*")
+        self.assertTrue(host_address.startswith("ngas."))
         host_address = ngamsFileUtils.get_fqdn(NGAMS_HOST_REMOTE, "ngas", "example.com")
         self.assertEqual(host_address, "ngas.example.com")
         host_address = ngamsFileUtils.get_fqdn(NGAMS_HOST_REMOTE, "ngas", None)


### PR DESCRIPTION
This is a quick fix but I think the `retrieve._handleCmdRetrieve()` function needs some further improvements. There are a few of issues:
1. The NGAS host ID may include the port value (e.g. `ngas01:7777`). There are few places in the code where we construct a URL (e.g. `host + ':' + port + '/' + command + ...`). This will often result in the URL `ngas01:7777:7777/RETRIEVE?...`. Somehow this still works most of the time in python 2 but the `urlparse` module in python 3 fails to parse the URL and throws an exception.
2. I think the `ngamsFileUtils.quickFileLocate()` function should really return a `NGAMS_HOST_CLUSTER` instead of `NGAMS_HOST_REMOTE` value. This makes more sense to me. Presently if the file is available in another node in the cluster it will end up being retrieved by the partner-sites routines. This will still work but it should really be handled as a redirect or as a proxy request depending on the config.
3. If the IP address is configured as `0.0.0.0` for all nodes in the cluster then the redirects will fail using this IP address
4. If the IP address is `0.0.0.0` then we have no alternative but to use the host ID. The problem with the host ID is that it does not contain the domain name. We should really construct a URL using the host ID, domain name and port address. The domain name is not always available as far as I can see.
Let me know what you think.