### PR TITLE
removed timeouts on long running http operations which must be allowe…

### DIFF
--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRREXEC.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRREXEC.py
@@ -777,7 +777,9 @@ class MirrexecCommandSender(threading.Thread):
             }
 
             start_time = time.time()
-            response = ngamsHttpUtils.httpGet(host, int(port), 'MIRREXEC', pars=pars, timeout=self.rx_timeout)
+            # it is important to not let this operation time out. If it times out then the files being fetched will
+            # be eligable for re-fetching even though the spawned threads may still be executing. Chaos ensues.
+            response = ngamsHttpUtils.httpGet(host, int(port), 'MIRREXEC', pars=pars)
             with contextlib.closing(response):
                 failed = response.status != NGAMS_HTTP_SUCCESS or NGAMS_FAILURE in utils.b2s(response.read())
             elapsed_time = time.time() - start_time

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRRTABLE.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_MIRRTABLE.py
@@ -192,8 +192,9 @@ def execute_mirroring(ngams_server, iteration):
             'n_threads': get_num_simultaneous_fetches_per_server(ngams_server)
         }
         host, port = ngams_server.get_self_endpoint()
-        # TODO: look at the HTTP response code
-        ngamsHttpUtils.httpGet(host, port, 'MIRREXEC', pars=pars, timeout=rx_timeout)
+        # it is important to not let this operation time out. If it times out then the files being fetched will 
+        # be eligable for re-fetching even though the spawned threads may still be executing. Chaos ensues.
+        ngamsHttpUtils.httpGet(host, port, 'MIRREXEC', pars=pars)
     except Exception:
         logger.exception("MIRREXEC command for iteration %d has failed", iteration)
     finally:


### PR DESCRIPTION
Please don't ask me to provide tests for this. I can't think how to do unit nor integration tests. 
Manual tests consist of:
- clear the mirroring bookkeeping table
- limit the number of files to fetch in a single mirroring iteration to 30 ( or round about)
- start mirroring. Wait until files are being fetched
- drop request packets using iptables
- let the FAILURES pile up
- note the highest iteration number- N
- revert the iptables 
- verify that all previously failed files are fetched
- verify that there are no FAILURES from iteration N+1

Before this change we got into a state where the FAILURES built up. By using a None timeout the mirroring stabilised again.

We plan to look at other ways of mirroring. Perhaps using subscription. Perhaps at the file-system level.