### PR TITLE
allow alma mirroring to always clean up at the start

### DIFF
--- a/src/ngamsServer/ngamsServer/ngamsMirroringControlThread.py
+++ b/src/ngamsServer/ngamsServer/ngamsMirroringControlThread.py
@@ -954,10 +954,20 @@ def mirror_control_thread(ngams_server, stop_event):
     :param ngams_server: Reference to server object (ngamsServer)
     :param stop_event: Stop event
     """
-    if ngams_server.getCfg().getVal("Mirroring[1].AlmaMirroring"):
+    # whether or not this is the ALMA mirroring thread (Mirrroring.Active) we always clean up any previous iterations
+    isAlma = ngams_server.getCfg().getVal("Mirroring[1].AlmaMirroring")
+    if isAlma:
         logger.info("ALMA mirroring control thread cleaning up from previous state")
         clean_up_mirroring(ngams_server)
 
+    if not ngams_server.getCfg().getMirroringActive():
+        if isAlma:
+            logger.info('not the mirroring master - stopping the mirroring control thread')
+        else:
+            logger.info('NGAS Mirroring not active - Mirroring Control Thread not started')
+        return
+
+    if isAlma:
         logger.info("ALMA mirroring control thread entering main server loop")
         while True:
             # Encapsulate this whole block to avoid that the thread dies in case a problem occurs,
@@ -995,6 +1005,7 @@ def mirror_control_thread(ngams_server, stop_event):
                 if stop_event.wait(5.0):
                     return
     else:
+        logger.info("NGAS Mirroring is active')
         # Generic Mirroring service
         initialise_mirroring(ngams_server)
 

--- a/src/ngamsServer/ngamsServer/ngamsMirroringControlThread.py
+++ b/src/ngamsServer/ngamsServer/ngamsMirroringControlThread.py
@@ -1005,7 +1005,7 @@ def mirror_control_thread(ngams_server, stop_event):
                 if stop_event.wait(5.0):
                     return
     else:
-        logger.info("NGAS Mirroring is active')
+        logger.info('NGAS Mirroring is active')
         # Generic Mirroring service
         initialise_mirroring(ngams_server)
 

--- a/src/ngamsServer/ngamsServer/ngamsServer.py
+++ b/src/ngamsServer/ngamsServer/ngamsServer.py
@@ -1180,10 +1180,9 @@ class ngamsServer(object):
 
     def startMirControlThread(self):
         """Starts the Mirroring Control Thread"""
-        if not self.getCfg().getMirroringActive():
-            logger.info("NGAS Mirroring not active - Mirroring Control Thread not started")
-            return
-        logger.info("NGAS Mirroring is active - Starting Mirroring Control Thread")
+        # the mirroring thread is _always_ started and then may do nothing, depending on
+        # the configuration. It does this for the benefit of ALMA mirroring which performs
+        # clean-up in the database when it starts.
         self._mir_control_thread.start(self)
 
 


### PR DESCRIPTION
Not a nice solution in the end. In our old NGAS version we used to not care about non-alma mirroring so the mirroring thread always started, executed cleanup, and exited.

Anyway, this fixes many issues we were seeing with servers bring stopped / started / killed.