### PR TITLE
Email file memory fix

### DIFF
--- a/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
@@ -65,7 +65,9 @@ def parse_multipart_primary_header(file_path):
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
             first_line = line.lower()
-            if not first_line.startswith("message-id") and not first_line.startswith("mime-version"):
+            if not first_line.startswith("date")\
+                    and not first_line.startswith("message-id")\
+                    and not first_line.startswith("mime-version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()

--- a/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
@@ -62,21 +62,15 @@ def parse_multipart_primary_header(file_path):
     try:
         # We read file using binary and decode to utf-8 later to ensure python 2/3 compatibility
         with open(file_path, 'rb') as fo:
-            # Verify the file uses MIME format
-            line = fo.readline().decode(encoding="utf-8")
-            first_line = line.lower()
-            if not first_line.startswith("date")\
-                    and not first_line.startswith("message-id")\
-                    and not first_line.startswith("mime-version"):
-                raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
-            # Read primary header block lines into the parser
+            # We only want to read the primary header block lines into the parser
+            # According to section 3.1 of RFC822:
+            # A message consists of header fields and, optionally, a body. The body is simply a sequence of lines
+            # containing ASCII characters. It is separated from the headers by a null line (i.e., a  line with nothing
+            # preceding the CRLF).
             feedparser = email.parser.FeedParser()
-            feedparser.feed(line)
             for line in fo:
                 line = line.decode(encoding="utf-8")
-                if line.startswith("\n"):
-                    continue
-                if line.startswith("--"):
+                if line.startswith("\r") or line.startswith("\n") or line.startswith("--"):
                     break
                 feedparser.feed(line)
             return feedparser.close()

--- a/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
@@ -64,7 +64,7 @@ def parse_multipart_primary_header(file_path):
         with open(file_path, 'rb') as fo:
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
-            if not line.startswith("Message-ID") or not line.startswith("MIME-Version"):
+            if not line.startswith("Message-ID") and not line.startswith("MIME-Version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()

--- a/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
@@ -64,7 +64,8 @@ def parse_multipart_primary_header(file_path):
         with open(file_path, 'rb') as fo:
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
-            if not line.startswith("Message-ID") and not line.startswith("MIME-Version"):
+            first_line = line.lower()
+            if not first_line.startswith("message-id") and not first_line.startswith("mime-version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()

--- a/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
@@ -64,7 +64,7 @@ def parse_multipart_primary_header(file_path):
         with open(file_path, 'rb') as fo:
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
-            if not line.startswith("MIME-Version: 1.0"):
+            if not line.startswith("Message-ID") or not line.startswith("MIME-Version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()
@@ -73,7 +73,7 @@ def parse_multipart_primary_header(file_path):
                 line = line.decode(encoding="utf-8")
                 if line.startswith("\n"):
                     continue
-                if line.startswith("--MIME_boundary"):
+                if line.startswith("--"):
                     break
                 feedparser.feed(line)
             return feedparser.close()

--- a/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/alma/ngamsAlmaMultipart.py
@@ -35,11 +35,11 @@ Note that the plug-in is implemented for the usage for ALMA. If used in other co
 the individual context should be implemented and NG/AMS configured to use it.
 """
 
-import email
+import email.parser
+import email.policy
 import logging
 import os
 import re
-import sys
 
 from ngamsLib import ngamsPlugInApi
 from ngamsLib import ngamsCore
@@ -49,11 +49,6 @@ PLUGIN_ID = __name__
 
 # This matches the new UID structure uid://X1/X2/X3#kdgflf
 UID_EXPRESSION = re.compile(r"^[uU][iI][dD]:/(/[xX][0-9,a-f,A-F]+){3}(#\w{1,}){0,}$")
-
-# Python 2/3 workaround
-message_from_file = email.message_from_file
-if sys.version_info[0] > 2:
-    message_from_file = email.message_from_binary_file
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +63,7 @@ def specific_treatment(file_path):
     filename = os.path.basename(file_path)
     try:
         with open(file_path, "rb") as fo:
-            mime_message = message_from_file(fo)
+            mime_message = email.parser.BytesHeaderParser(policy=email.policy.default).parse(fo)
     except Exception as e:
         raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "Failed to open file: " + str(e)]))
 

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_HTTPFETCH.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsCmd_HTTPFETCH.py
@@ -175,7 +175,7 @@ def save_to_file(ngams_server, request_properties, target_filename, block_size, 
 
     # Raise exception if bytes received were less than expected
     if remaining_size != 0:
-        msg = "No all expected data arrived, {:d} bytes left to read".format(remaining_size)
+        msg = "Not all expected data arrived, {:d} bytes left to read".format(remaining_size)
         raise ngamsFailedDownloadException.FailedDownloadException(msg)
 
     # Now check the freshly calculated CRC value against the stored CRC value

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
@@ -65,7 +65,9 @@ def parse_multipart_primary_header(file_path):
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
             first_line = line.lower()
-            if not first_line.startswith("message-id") and not first_line.startswith("mime-version"):
+            if not first_line.startswith("date")\
+                    and not first_line.startswith("message-id")\
+                    and not first_line.startswith("mime-version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
@@ -62,21 +62,15 @@ def parse_multipart_primary_header(file_path):
     try:
         # We read file using binary and decode to utf-8 later to ensure python 2/3 compatibility
         with open(file_path, 'rb') as fo:
-            # Verify the file uses MIME format
-            line = fo.readline().decode(encoding="utf-8")
-            first_line = line.lower()
-            if not first_line.startswith("date")\
-                    and not first_line.startswith("message-id")\
-                    and not first_line.startswith("mime-version"):
-                raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
-            # Read primary header block lines into the parser
+            # We only want to read the primary header block lines into the parser
+            # According to section 3.1 of RFC822:
+            # A message consists of header fields and, optionally, a body. The body is simply a sequence of lines
+            # containing ASCII characters. It is separated from the headers by a null line (i.e., a  line with nothing
+            # preceding the CRLF).
             feedparser = email.parser.FeedParser()
-            feedparser.feed(line)
             for line in fo:
                 line = line.decode(encoding="utf-8")
-                if line.startswith("\n"):
-                    continue
-                if line.startswith("--"):
+                if line.startswith("\r") or line.startswith("\n") or line.startswith("--"):
                     break
                 feedparser.feed(line)
             return feedparser.close()

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
@@ -64,7 +64,7 @@ def parse_multipart_primary_header(file_path):
         with open(file_path, 'rb') as fo:
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
-            if not line.startswith("Message-ID") or not line.startswith("MIME-Version"):
+            if not line.startswith("Message-ID") and not line.startswith("MIME-Version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
@@ -64,7 +64,8 @@ def parse_multipart_primary_header(file_path):
         with open(file_path, 'rb') as fo:
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
-            if not line.startswith("Message-ID") and not line.startswith("MIME-Version"):
+            first_line = line.lower()
+            if not first_line.startswith("message-id") and not first_line.startswith("mime-version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
@@ -64,7 +64,7 @@ def parse_multipart_primary_header(file_path):
         with open(file_path, 'rb') as fo:
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
-            if not line.startswith("MIME-Version: 1.0"):
+            if not line.startswith("Message-ID") or not line.startswith("MIME-Version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()
@@ -73,7 +73,7 @@ def parse_multipart_primary_header(file_path):
                 line = line.decode(encoding="utf-8")
                 if line.startswith("\n"):
                     continue
-                if line.startswith("--MIME_boundary"):
+                if line.startswith("--"):
                     break
                 feedparser.feed(line)
             return feedparser.close()

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
@@ -36,7 +36,6 @@ the individual context should be implemented and NG/AMS configured to use it.
 """
 
 import email.parser
-import email.policy
 import logging
 import os
 import re
@@ -53,6 +52,35 @@ UID_EXPRESSION = re.compile(r"^[uU][iI][dD]://[aAbBcCzZxX][0-9,a-z,A-Z]+(/[xX][0
 logger = logging.getLogger(__name__)
 
 
+def parse_multipart_primary_header(file_path):
+    """
+    Parses email MIME document file and extracts the primary header elements
+    :param file_path: File path
+    :return: email message object
+    """
+    filename = os.path.basename(file_path)
+    try:
+        # We read file using binary and decode to utf-8 later to ensure python 2/3 compatibility
+        with open(file_path, 'rb') as fo:
+            # Verify the file uses MIME format
+            line = fo.readline().decode(encoding="utf-8")
+            if not line.startswith("MIME-Version: 1.0"):
+                raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
+            # Read primary header block lines into the parser
+            feedparser = email.parser.FeedParser()
+            feedparser.feed(line)
+            for line in fo:
+                line = line.decode(encoding="utf-8")
+                if line.startswith("\n"):
+                    continue
+                if line.startswith("--MIME_boundary"):
+                    break
+                feedparser.feed(line)
+            return feedparser.close()
+    except Exception as e:
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "Failed to open file: " + str(e)]))
+
+
 def specific_treatment(file_path):
     """
     Method contains the specific treatment of the file passed from NG/AMS
@@ -61,14 +89,9 @@ def specific_treatment(file_path):
              file without extension. file_type is the mime-type from the header.
     """
     filename = os.path.basename(file_path)
-    try:
-        with open(file_path, "rb") as fo:
-            mime_message = email.parser.BytesHeaderParser(policy=email.policy.default).parse(fo)
-    except Exception as e:
-        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "Failed to open file: " + str(e)]))
-
+    mime_message = parse_multipart_primary_header(file_path)
     if mime_message is None:
-        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "Failed to parse mime message"]))
+        raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "Failed to parse MIME message"]))
 
     file_type = mime_message.get_content_type()
     alma_uid = mime_message["alma-uid"]
@@ -77,7 +100,7 @@ def specific_treatment(file_path):
     if alma_uid is None:
         raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE",
                                [filename, PLUGIN_ID,
-                                "Mandatory 'alma-uid' and/or 'Content-Location' parameter not found in mime header!"]))
+                                "Mandatory 'alma-uid' and/or 'Content-Location' parameter not found in MIME header!"]))
 
     if UID_EXPRESSION.match(alma_uid) is None:
         raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE",

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsDAPIMirroring.py
@@ -35,11 +35,11 @@ Note that the plug-in is implemented for the usage for ALMA. If used in other co
 the individual context should be implemented and NG/AMS configured to use it.
 """
 
-import email
+import email.parser
+import email.policy
 import logging
 import os
 import re
-import sys
 
 from ngamsLib import ngamsPlugInApi
 from ngamsLib import ngamsCore
@@ -49,11 +49,6 @@ PLUGIN_ID = __name__
 
 # Update for the new assignment of archive IDs (backwards compatible)
 UID_EXPRESSION = re.compile(r"^[uU][iI][dD]://[aAbBcCzZxX][0-9,a-z,A-Z]+(/[xX][0-9,a-z,A-Z]+){2}(#\w{1,}|/\w{0,}){0,}$")
-
-# Python 2/3 workaround
-message_from_file = email.message_from_file
-if sys.version_info[0] > 2:
-    message_from_file = email.message_from_binary_file
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +63,7 @@ def specific_treatment(file_path):
     filename = os.path.basename(file_path)
     try:
         with open(file_path, "rb") as fo:
-            mime_message = message_from_file(fo)
+            mime_message = email.parser.BytesHeaderParser(policy=email.policy.default).parse(fo)
     except Exception as e:
         raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "Failed to open file: " + str(e)]))
 

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsRegisterAlmaPlugIn.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsRegisterAlmaPlugIn.py
@@ -64,7 +64,9 @@ def parse_multipart_primary_header(file_path):
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
             first_line = line.lower()
-            if not first_line.startswith("message-id") and not first_line.startswith("mime-version"):
+            if not first_line.startswith("date")\
+                    and not first_line.startswith("message-id")\
+                    and not first_line.startswith("mime-version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsRegisterAlmaPlugIn.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsRegisterAlmaPlugIn.py
@@ -61,21 +61,15 @@ def parse_multipart_primary_header(file_path):
     try:
         # We read file using binary and decode to utf-8 later to ensure python 2/3 compatibility
         with open(file_path, 'rb') as fo:
-            # Verify the file uses MIME format
-            line = fo.readline().decode(encoding="utf-8")
-            first_line = line.lower()
-            if not first_line.startswith("date")\
-                    and not first_line.startswith("message-id")\
-                    and not first_line.startswith("mime-version"):
-                raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
-            # Read primary header block lines into the parser
+            # We only want to read the primary header block lines into the parser
+            # According to section 3.1 of RFC822:
+            # A message consists of header fields and, optionally, a body. The body is simply a sequence of lines
+            # containing ASCII characters. It is separated from the headers by a null line (i.e., a  line with nothing
+            # preceding the CRLF).
             feedparser = email.parser.FeedParser()
-            feedparser.feed(line)
             for line in fo:
                 line = line.decode(encoding="utf-8")
-                if line.startswith("\n"):
-                    continue
-                if line.startswith("--"):
+                if line.startswith("\r") or line.startswith("\n") or line.startswith("--"):
                     break
                 feedparser.feed(line)
             return feedparser.close()

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsRegisterAlmaPlugIn.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsRegisterAlmaPlugIn.py
@@ -63,7 +63,7 @@ def parse_multipart_primary_header(file_path):
         with open(file_path, 'rb') as fo:
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
-            if not line.startswith("MIME-Version: 1.0"):
+            if not line.startswith("Message-ID") or not line.startswith("MIME-Version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()
@@ -72,7 +72,7 @@ def parse_multipart_primary_header(file_path):
                 line = line.decode(encoding="utf-8")
                 if line.startswith("\n"):
                     continue
-                if line.startswith("--MIME_boundary"):
+                if line.startswith("--"):
                     break
                 feedparser.feed(line)
             return feedparser.close()

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsRegisterAlmaPlugIn.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsRegisterAlmaPlugIn.py
@@ -63,7 +63,7 @@ def parse_multipart_primary_header(file_path):
         with open(file_path, 'rb') as fo:
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
-            if not line.startswith("Message-ID") or not line.startswith("MIME-Version"):
+            if not line.startswith("Message-ID") and not line.startswith("MIME-Version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsRegisterAlmaPlugIn.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsRegisterAlmaPlugIn.py
@@ -63,7 +63,8 @@ def parse_multipart_primary_header(file_path):
         with open(file_path, 'rb') as fo:
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
-            if not line.startswith("Message-ID") and not line.startswith("MIME-Version"):
+            first_line = line.lower()
+            if not first_line.startswith("message-id") and not first_line.startswith("mime-version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
@@ -66,7 +66,9 @@ def parse_multipart_primary_header(file_path):
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
             first_line = line.lower()
-            if not first_line.startswith("message-id") and not first_line.startswith("mime-version"):
+            if not first_line.startswith("date")\
+                    and not first_line.startswith("message-id")\
+                    and not first_line.startswith("mime-version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
@@ -65,7 +65,7 @@ def parse_multipart_primary_header(file_path):
         with open(file_path, 'rb') as fo:
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
-            if not line.startswith("MIME-Version: 1.0"):
+            if not line.startswith("Message-ID") or not line.startswith("MIME-Version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()
@@ -74,7 +74,7 @@ def parse_multipart_primary_header(file_path):
                 line = line.decode(encoding="utf-8")
                 if line.startswith("\n"):
                     continue
-                if line.startswith("--MIME_boundary"):
+                if line.startswith("--"):
                     break
                 feedparser.feed(line)
             return feedparser.close()

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
@@ -65,7 +65,7 @@ def parse_multipart_primary_header(file_path):
         with open(file_path, 'rb') as fo:
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
-            if not line.startswith("Message-ID") or not line.startswith("MIME-Version"):
+            if not line.startswith("Message-ID") and not line.startswith("MIME-Version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsSdmMultipart.py
@@ -65,7 +65,8 @@ def parse_multipart_primary_header(file_path):
         with open(file_path, 'rb') as fo:
             # Verify the file uses MIME format
             line = fo.readline().decode(encoding="utf-8")
-            if not line.startswith("Message-ID") and not line.startswith("MIME-Version"):
+            first_line = line.lower()
+            if not first_line.startswith("message-id") and not first_line.startswith("mime-version"):
                 raise Exception(genLog("NGAMS_ER_DAPI_BAD_FILE", [filename, PLUGIN_ID, "File is not MIME file format"]))
             # Read primary header block lines into the parser
             feedparser = email.parser.FeedParser()


### PR DESCRIPTION
When I ported the old code from using the rc822 module to using the email instead I did not realise that I had introduced a new problem. The old rf822 module was very memory efficient where as the new email modules appears to read the entire file contents into memory. I have written a simple file parer that only pareses the MIME file primary header unit. This is all we need for ALMA when trying to determine if the file is a `multipart/mixed` or `multipart/related`.