### PR TITLE
Use traditional version constraining method

### DIFF
--- a/src/ngamsServer/setup.py
+++ b/src/ngamsServer/setup.py
@@ -20,6 +20,7 @@
 #    MA 02111-1307  USA
 #
 import os
+import sys
 
 from setuptools import setup, find_packages
 
@@ -29,12 +30,13 @@ with open('../../VERSION') as vfile:
             version = line.split("NGAMS_SW_VER ")[1].strip()[1:-1]
             break
 
-
+python_daemon_version_constraint = ''
+if sys.version_info <= (3,0):
+    python_daemon_version_constraint = '<=2.3.0'
 install_requires = [
     'ngamsCore',
-    'netifaces',
-    'python-daemon <= 2.3.0; python_version < "3"',
-    'python-daemon; python_version >= "3"',
+    'netifaces',                                                                                                                                            
+    'python-daemon' + python_daemon_version_constraint
 ]
 
 # Users might opt out from depending on crc32c


### PR DESCRIPTION
Since we are still supporting not only old versions of python, but also old versions of setuptools, we can't rely on PEP-508 dependency specifications being supported. These were added around 2016 in setuptools version 20, while RHEL7 comes with 0.9.8, thus not supporting this format