### PR TITLE
Update ngamsGenDapi

### DIFF
--- a/src/ngamsCore/ngamsLib/ngamsFileInfo.py
+++ b/src/ngamsCore/ngamsLib/ngamsFileInfo.py
@@ -278,7 +278,7 @@ class ngamsFileInfo:
 
         Returns:    Reference to object itself.
         """
-        self.__uncompressedFileSize = size
+        self.__uncompressedFileSize = int(size)
         return self
 
 

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsGenDapi.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsGenDapi.py
@@ -77,18 +77,14 @@ UNCOMPRESSED_FILE_SIZE = "uncompressed_file_size"
 NO_COMPRESSION = "NONE"
 
 
-def get_req_param(reqPropsObj, param, default):
-    return reqPropsObj[param] if param in reqPropsObj else default
-
-
 def is_compression_defined(compression):
     return compression is not None and compression.upper() != NO_COMPRESSION
 
 
 def extract_compression_params(reqPropsObj, plugin_pars):
-    plugin_pars[COMPRESSION] = get_req_param(reqPropsObj, COMPRESSION, None)
-    plugin_pars[COMPRESSION_EXT] = get_req_param(reqPropsObj, COMPRESSION_EXT, None)
-    uncomprSize = get_req_param(reqPropsObj, UNCOMPRESSED_FILE_SIZE, None)
+    plugin_pars[COMPRESSION] = reqPropsObj.get(COMPRESSION)
+    plugin_pars[COMPRESSION_EXT] = reqPropsObj.get(COMPRESSION_EXT)
+    uncomprSize = reqPropsObj.get(UNCOMPRESSED_FILE_SIZE)
     plugin_pars[UNCOMPRESSED_FILE_SIZE] = int(uncomprSize) if uncomprSize else None
 
     if is_compression_defined(plugin_pars[COMPRESSION]) and not (plugin_pars[COMPRESSION_EXT] or uncomprSize):

--- a/src/ngamsPlugIns/ngamsPlugIns/ngamsGenDapi.py
+++ b/src/ngamsPlugIns/ngamsPlugIns/ngamsGenDapi.py
@@ -19,7 +19,7 @@
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 #    MA 02111-1307  USA
 #
-#******************************************************************************
+# ******************************************************************************
 #
 # "@(#) $Id: ngamsGenDapi.py,v 1.3 2010/05/21 12:28:12 jagonzal Exp $"
 #
@@ -67,35 +67,33 @@ import time
 from ngamsLib import ngamsPlugInApi, ngamsLib
 from ngamsLib.ngamsCore import genLog, toiso8601, FMT_DATE_ONLY
 
-
 logger = logging.getLogger(__name__)
 
-TARG_MIME_TYPE  = "target_mime_type"
-FILE_ID         = "file_id"
-COMPRESSION     = "compression"
+TARG_MIME_TYPE = "target_mime_type"
+FILE_ID = "file_id"
+COMPRESSION = "compression"
 COMPRESSION_EXT = "compression_ext"
+UNCOMPRESSED_FILE_SIZE = "uncompressed_file_size"
 
 # Constants.
-NO_COMPRESSION  = "NONE"
+NO_COMPRESSION = "NONE"
+
+
+def get_req_param(reqPropsObj, param, default):
+    return reqPropsObj[param] if param in reqPropsObj else default
 
 
 def extract_compression_params(reqPropsObj, plugin_pars):
+    plugin_pars[COMPRESSION] = get_req_param(reqPropsObj, COMPRESSION, None)
+    plugin_pars[COMPRESSION_EXT] = get_req_param(reqPropsObj, COMPRESSION_EXT, None)
+    plugin_pars[UNCOMPRESSED_FILE_SIZE] = get_req_param(reqPropsObj, UNCOMPRESSED_FILE_SIZE, None)
 
-    plugin_pars[COMPRESSION]     = None
-    plugin_pars[COMPRESSION_EXT] = None
+    if plugin_pars[COMPRESSION] and not (plugin_pars[COMPRESSION_EXT] or plugin_pars[UNCOMPRESSED_FILE_SIZE]):
+        raise Exception(genLog("NGAMS_ER_DAPI", ["Parameter compression requires compression_ext"
+                                                 "or uncompressed_file_size"]))
 
-    if COMPRESSION in reqPropsObj:
-        plugin_pars[COMPRESSION] = reqPropsObj[COMPRESSION]
-    if COMPRESSION_EXT in reqPropsObj:
-        plugin_pars[COMPRESSION_EXT] = reqPropsObj[COMPRESSION_EXT]
-    if ((plugin_pars[COMPRESSION] and plugin_pars[COMPRESSION_EXT] is None) or
-        (not plugin_pars[COMPRESSION] and plugin_pars[COMPRESSION_EXT] is not None)):
-        raise Exception(genLog("NGAMS_ER_DAPI",
-                                ["Parameters compression and compression_ext"
-                                 "must be given together."]))
 
-def handlePars(reqPropsObj,
-               parDic):
+def handlePars(reqPropsObj, parDic):
     """
     Parse/handle the HTTP parameters.
 
@@ -107,33 +105,39 @@ def handlePars(reqPropsObj,
     """
     # Get parameters.
     logger.debug("Get request parameters")
-    parDic[TARG_MIME_TYPE]  = None
-    parDic[FILE_ID]         = None
+    parDic[TARG_MIME_TYPE] = None
+    parDic[FILE_ID] = None
 
-    if (reqPropsObj.hasHttpPar(TARG_MIME_TYPE)):
+    if reqPropsObj.hasHttpPar(TARG_MIME_TYPE):
         parDic[TARG_MIME_TYPE] = reqPropsObj.getHttpPar(TARG_MIME_TYPE)
 
     # If the file_id is not given, we derive it from the name of the URI.
-    if (reqPropsObj.hasHttpPar(FILE_ID)):
+    if reqPropsObj.hasHttpPar(FILE_ID):
         parDic[FILE_ID] = reqPropsObj.getHttpPar(FILE_ID)
-    if (not parDic[FILE_ID]):
-        if (reqPropsObj.getFileUri().find("file_id=") > 0):
+    if not parDic[FILE_ID]:
+        if reqPropsObj.getFileUri().find("file_id=") > 0:
             file_id = reqPropsObj.getFileUri().split("file_id=")[1]
             parDic[FILE_ID] = os.path.basename(file_id)
             logger.info("No file_id given, but found one in the URI: %s", parDic[FILE_ID])
         else:
             parDic[FILE_ID] = os.path.basename(reqPropsObj.getFileUri())
-            logger.info("No file_id given, using basename of fileUri: %s", 
-                 parDic[FILE_ID])
+            logger.info("No file_id given, using basename of fileUri: %s",
+                        parDic[FILE_ID])
 
     extract_compression_params(reqPropsObj, parDic)
 
-def _compress_data(plugin_pars):
-    return plugin_pars[COMPRESSION]
 
-def compressFile(srvObj,
-                 reqPropsObj,
-                 parDic):
+def _compress_data(plugin_pars):
+    return plugin_pars[COMPRESSION] and plugin_pars[COMPRESSION_EXT]
+
+
+def _already_compressed_data(plugin_pars):
+    return plugin_pars[COMPRESSION] and plugin_pars[UNCOMPRESSED_FILE_SIZE]
+
+
+def compress_file(srvObj,
+                  reqPropsObj,
+                  parDic):
     """
     Compress the file if required.
 
@@ -151,21 +155,24 @@ def compressFile(srvObj,
                   (tuple).
     """
     stFn = reqPropsObj.getStagingFilename()
-
-    # If a compression application is specified, apply this.
-    uncomprSize = ngamsPlugInApi.getFileSize(stFn)
+    compression = NO_COMPRESSION
     comprExt = ""
+    uncomprSize = ngamsPlugInApi.getFileSize(stFn)
+    if parDic[TARG_MIME_TYPE]:
+        mime_type = parDic[TARG_MIME_TYPE]
+    else:
+        mime_type = reqPropsObj.getMimeType()
     if _compress_data(parDic):
         logger.debug("Compressing file using: %s ...", parDic[COMPRESSION])
         compCmd = "%s %s" % (parDic[COMPRESSION], stFn)
         compress_start = time.time()
         logger.debug("Compressing file with command: %s", compCmd)
         with open(os.devnull, 'w') as f:
-            exitCode = subprocess.call([parDic[COMPRESSION], stFn], stdout = f, stderr = f)
+            exitCode = subprocess.call([parDic[COMPRESSION], stFn], stdout=f, stderr=f)
         # If the compression fails, assume that it is because the file is not
         # compressible (although it could also be due to lack of disk space).
-        if (exitCode == 0):
-            if (parDic[COMPRESSION_EXT]):
+        if exitCode == 0:
+            if parDic[COMPRESSION_EXT]:
                 stFn = stFn + "." + parDic[COMPRESSION_EXT]
                 comprExt = parDic[COMPRESSION_EXT]
             # Remember to update Staging Filename in the Request Properties
@@ -173,29 +180,26 @@ def compressFile(srvObj,
             reqPropsObj.setStagingFilename(stFn)
 
             # Handle mime-type
-            if (parDic[TARG_MIME_TYPE]):
-                format = parDic[TARG_MIME_TYPE]
+            if parDic[TARG_MIME_TYPE]:
+                mime_type = parDic[TARG_MIME_TYPE]
             else:
-                format = ngamsPlugInApi.determineMimeType(srvObj.getCfg(),
-                                                          stFn)
+                mime_type = ngamsPlugInApi.determineMimeType(srvObj.getCfg(), stFn)
             compression = parDic[COMPRESSION]
 
             logger.debug("File compressed. Time: %.3fs", time.time() - compress_start)
         else:
             # Carry on with the original file. We take the original mime-type
             # as the target mime-type.
-            format = reqPropsObj.getMimeType()
+            mime_type = reqPropsObj.getMimeType()
             compression = NO_COMPRESSION
-    else:
-        # Handle mime-type
-        if (parDic[TARG_MIME_TYPE]):
-            format = parDic[TARG_MIME_TYPE]
-        else:
-            format = reqPropsObj.getMimeType()
-        compression = NO_COMPRESSION
+    elif _already_compressed_data(parDic):
+        logger.debug("Already compressed file: %s %s %d", parDic[COMPRESSION], parDic[COMPRESSION_EXT],
+                     parDic[UNCOMPRESSED_FILE_SIZE])
+        compression = parDic[COMPRESSION]
+        uncomprSize = parDic[UNCOMPRESSED_FILE_SIZE]
 
     archFileSize = ngamsPlugInApi.getFileSize(reqPropsObj.getStagingFilename())
-    return uncomprSize, archFileSize, format, compression, comprExt
+    return uncomprSize, archFileSize, mime_type, compression, comprExt
 
 
 def checkForDblExt(complFilename,
@@ -216,6 +220,7 @@ def checkForDblExt(complFilename,
     complFilename = ngamsLib.remove_duplicated_extension(complFilename)
     relFilename = ngamsLib.remove_duplicated_extension(relFilename)
     return complFilename, relFilename
+
 
 # Signals the server whether this plug-in modifies its incoming contents (or not)
 def modifies_content(srvObj, reqPropsObj):
@@ -240,34 +245,30 @@ def ngamsGenDapi(srvObj,
     # For now the exception handling is pretty basic:
     # If something goes wrong during the handling it is tried to
     # move the temporary file to the Bad Files Area of the disk.
-    logger.debug("Plug-In handling data for file: %s",
-         os.path.basename(reqPropsObj.getFileUri()))
+    baseFilename = os.path.basename(reqPropsObj.getFileUri())
+    logger.debug("Plug-In handling data for file: %s", baseFilename)
     try:
         parDic = {}
         handlePars(reqPropsObj, parDic)
         diskInfo = reqPropsObj.getTargDiskInfo()
-        stgFile = reqPropsObj.getStagingFilename()
-        ext = os.path.splitext(stgFile)[1][1:]
 
         # Generate file information.
         logger.debug("Generate file information")
         dateDir = toiso8601(fmt=FMT_DATE_ONLY)
-        fileVersion, relPath, relFilename,\
-                     complFilename, fileExists =\
-                     ngamsPlugInApi.genFileInfo(srvObj.getDb(),
-                                                srvObj.getCfg(),
-                                                reqPropsObj, diskInfo,
-                                                reqPropsObj.\
-                                                getStagingFilename(),
-                                                parDic[FILE_ID],
-                                                parDic[FILE_ID], [dateDir])
+        fileVersion, relPath, relFilename, complFilename, fileExists = \
+            ngamsPlugInApi.genFileInfo(srvObj.getDb(),
+                                       srvObj.getCfg(),
+                                       reqPropsObj, diskInfo,
+                                       reqPropsObj.getStagingFilename(),
+                                       parDic[FILE_ID],
+                                       baseFilename, [dateDir])
         complFilename, relFilename = checkForDblExt(complFilename,
                                                     relFilename)
 
         # Compress the file if requested.
-        uncomprSize, archFileSize, format, compression, comprExt =\
-                     compressFile(srvObj, reqPropsObj, parDic)
-        if (comprExt != ""):
+        uncomprSize, archFileSize, mime_type, compression, comprExt = \
+            compress_file(srvObj, reqPropsObj, parDic)
+        if comprExt != "":
             complFilename += ".%s" % comprExt
             relFilename += ".%s" % comprExt
 
@@ -275,7 +276,7 @@ def ngamsGenDapi(srvObj,
         return ngamsPlugInApi.genDapiSuccessStat(diskInfo.getDiskId(),
                                                  relFilename,
                                                  parDic[FILE_ID],
-                                                 fileVersion, format,
+                                                 fileVersion, mime_type,
                                                  archFileSize, uncomprSize,
                                                  compression, relPath,
                                                  diskInfo.getSlotId(),

--- a/test/plugins/test_gen_dapi.py
+++ b/test/plugins/test_gen_dapi.py
@@ -1,0 +1,112 @@
+#
+#    ICRAR - International Centre for Radio Astronomy Research
+#    (c) UWA - The University of Western Australia, 2020
+#    Copyright by UWA (in the framework of the ICRAR)
+#    All rights reserved
+#
+#    This library is free software; you can redistribute it and/or
+#    modify it under the terms of the GNU Lesser General Public
+#    License as published by the Free Software Foundation; either
+#    version 2.1 of the License, or (at your option) any later version.
+#
+#    This library is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#    Lesser General Public License for more details.
+#
+#    You should have received a copy of the GNU Lesser General Public
+#    License along with this library; if not, write to the Free Software
+#    Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+#    MA 02111-1307  USA
+#
+from test import ngamsTestLib
+from uuid import uuid4
+import os
+
+
+class TestGenDapi(ngamsTestLib.ngamsTestSuite):
+    OCTET_STREAM = 'application/octet-stream'
+
+    def test_archive_and_retrieve_file(self):
+        """ test basic archive/retrieve sequence, with a user-defined file ID """
+
+        file_id = str(uuid4())
+        self.prepExtSrv()
+        self.archive('src/TinyTestFile.fits', pars=(('mime_type', self.OCTET_STREAM),
+                                                    ('file_id', file_id),))
+        self.retrieve(file_id, targetFile=ngamsTestLib.tmp_path())
+
+    def test_archive_and_compress_file(self):
+        """ test compression when archiving a file """
+
+        file_id = str(uuid4())
+        self.prepExtSrv()
+        self.archive('src/SmallFile.fits', pars=(('compression', 'gzip'),
+                                                 ('compression_ext', 'gz'),
+                                                 ('mime_type', self.OCTET_STREAM),
+                                                 ('target_mime_type', self.OCTET_STREAM),
+                                                 ('file_id', file_id)))
+        status = self.status(pars=(('file_id', file_id),))
+        file_info = status.getDiskStatusList()[0].getFileObjList()[0]
+        self.assertEqual(file_id, file_info.getFileId())
+        self.assertEqual('SmallFile.fits.gz', os.path.basename(file_info.getFilename()))
+        self.assertEqual('gzip', file_info.getCompression())
+        self.assertEqual(69120, file_info.getUncompressedFileSize())
+        self.assertEqual(self.OCTET_STREAM, file_info.getFormat())
+
+    def test_compression_none(self):
+        """ test special case of compression=none, meaning no compression """
+
+        file_id = str(uuid4())
+        self.prepExtSrv()
+        self.archive('src/SmallFile.fits', pars=(('compression', 'none'),
+                                                 ('mime_type', self.OCTET_STREAM),
+                                                 ('file_id', file_id)))
+        status = self.status(pars=(('file_id', file_id),))
+        file_info = status.getDiskStatusList()[0].getFileObjList()[0]
+        self.assertEqual(file_id, file_info.getFileId())
+        self.assertEqual('SmallFile.fits', os.path.basename(file_info.getFilename()))
+        self.assertEqual('NONE', file_info.getCompression())
+        self.assertEqual(69120, file_info.getFileSize())
+        self.assertEqual(69120, file_info.getUncompressedFileSize())
+        self.assertEqual(self.OCTET_STREAM, file_info.getFormat())
+
+    def test_archive_compressed_file(self):
+        """
+        test passing the uncompressed file size when archiving an already compressed file.
+        """
+
+        file_id = str(uuid4())
+        self.prepExtSrv()
+        self.archive('src/SmallFile.fits.gz', pars=(('compression', 'gzip'),
+                                                    ('uncompressed_file_size', 69120),
+                                                    ('mime_type', self.OCTET_STREAM),
+                                                    ('file_id', file_id)))
+        status = self.status(pars=(('file_id', file_id),))
+        file_info = status.getDiskStatusList()[0].getFileObjList()[0]
+        self.assertEqual(file_id, file_info.getFileId())
+        self.assertEqual('SmallFile.fits.gz', os.path.basename(file_info.getFilename()))
+        self.assertEqual('gzip', file_info.getCompression())
+        self.assertEqual(45823, file_info.getFileSize())
+        self.assertEqual(69120, file_info.getUncompressedFileSize())
+        self.assertEqual('1379947874', file_info.getChecksum())
+        self.assertEqual(self.OCTET_STREAM, file_info.getFormat())
+
+    def test_archive_file_with_negative_checksum(self):
+        """
+        test that the (negative) checksum computed using ngamsCrc32 is just a different representation
+        of the (positive) checksum computed by NGAS
+        TODO: the original idea of this test was to pass the checksum to the archive command but this is currently
+            not supported because the checksum should be given as HTTP header
+        """
+
+        file_id = str(uuid4())
+        expected_checksum = str(-599448499 & 0xffffffff)
+        self.prepExtSrv()
+        self.archive('src/TinyTestFile.fits', pars=(('mime_type', self.OCTET_STREAM),
+                                                    ('file_id', file_id),))
+        status = self.status(pars=(('file_id', file_id),))
+        file_info = status.getDiskStatusList()[0].getFileObjList()[0]
+        self.assertEqual(file_id, file_info.getFileId())
+        self.assertEqual('TinyTestFile.fits', os.path.basename(file_info.getFilename()))
+        self.assertEqual(expected_checksum, file_info.getChecksum())

--- a/test/plugins/test_gen_dapi.py
+++ b/test/plugins/test_gen_dapi.py
@@ -91,22 +91,3 @@ class TestGenDapi(ngamsTestLib.ngamsTestSuite):
         self.assertEqual(69120, file_info.getUncompressedFileSize())
         self.assertEqual('1379947874', file_info.getChecksum())
         self.assertEqual(self.OCTET_STREAM, file_info.getFormat())
-
-    def test_archive_file_with_negative_checksum(self):
-        """
-        test that the (negative) checksum computed using ngamsCrc32 is just a different representation
-        of the (positive) checksum computed by NGAS
-        TODO: the original idea of this test was to pass the checksum to the archive command but this is currently
-            not supported because the checksum should be given as HTTP header
-        """
-
-        file_id = str(uuid4())
-        expected_checksum = str(-599448499 & 0xffffffff)
-        self.prepExtSrv()
-        self.archive('src/TinyTestFile.fits', pars=(('mime_type', self.OCTET_STREAM),
-                                                    ('file_id', file_id),))
-        status = self.status(pars=(('file_id', file_id),))
-        file_info = status.getDiskStatusList()[0].getFileObjList()[0]
-        self.assertEqual(file_id, file_info.getFileId())
-        self.assertEqual('TinyTestFile.fits', os.path.basename(file_info.getFilename()))
-        self.assertEqual(expected_checksum, file_info.getChecksum())


### PR DESCRIPTION
This PR contains the following changes and a few code (and documentation) improvements. The changes are mostly backward compatible (except point 3 which IMO is a bug fix) and driven by ESO needs. We could in principle create an ESO specific plugin but I would prefer to keep using the generic plugin for our archiving needs.

1) new parameter `uncompressed_file_size`. If the file is already compressed, this parameter can be used to specify the file size before compression so NGAS can save this information in the DB.
2) Support for `compression=none`. Although it may seem a bit silly because we get the same result by not passing this parameter at all, this small feature allow us to minimise the changes to our system when migrating to the new NGAS.
3) Bug fix. `file_id` was used also as file basename, which IMO is wrong (line 264). Now `file_id` sets only the file ID, not the file name. This change is backward incompatible but I think it's OK because: a) it can be considered as a bug fix, b) probably nobody else is using the system in this way, i.e. passing the file ID. We need this feature at ESO.

CC: @smclay 